### PR TITLE
Label test points

### DIFF
--- a/pcb/airbrake_mod.kicad_pcb
+++ b/pcb/airbrake_mod.kicad_pcb
@@ -687,6 +687,7 @@
 			(at 3.535534 0 45)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "9864978e-2615-4e92-8067-925117b2f9af")
 			(effects
 				(font
@@ -2308,6 +2309,7 @@
 			(at 0 1.7375 0)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "a4febfae-305c-48ae-b0b4-3a1c33c5c5a6")
 			(effects
 				(font
@@ -2423,6 +2425,7 @@
 			(at 0 -2.000001 90)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "cd6a09cf-b240-4c03-b2ed-c5edd4b4205a")
 			(effects
 				(font
@@ -3144,6 +3147,7 @@
 			(at -3 0 0)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "0e1f64f2-cb3e-4cc8-929b-8fe6cf60010b")
 			(effects
 				(font
@@ -3663,6 +3667,7 @@
 			(at 0 1.414214 45)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "fa9ecf74-95f9-475c-8ac1-78c1cc4ab27d")
 			(effects
 				(font
@@ -4097,6 +4102,7 @@
 			(at -3.2625 0 90)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "d8df025b-a646-4de8-a1ab-36b294a96eb3")
 			(effects
 				(font
@@ -5601,6 +5607,7 @@
 			(at -3 0 0)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "64793731-d23d-4877-ba6d-4d71b250d5ba")
 			(effects
 				(font
@@ -6180,6 +6187,7 @@
 			(at -3 0 0)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "c8bb1962-0837-4c94-9977-d1716e690b66")
 			(effects
 				(font
@@ -6295,6 +6303,7 @@
 			(at -2.12132 0.707107 45)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "37a84476-f414-4d1c-9ccc-f325df3edca1")
 			(effects
 				(font
@@ -10513,6 +10522,7 @@
 			(at 3.2625 0 90)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "f8c1a38e-ad92-4f5b-a8c1-a759b409c96e")
 			(effects
 				(font
@@ -10628,6 +10638,7 @@
 			(at 3.535534 0 45)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "ccd8b75c-10df-4a2d-8bab-34f99de05595")
 			(effects
 				(font
@@ -11655,6 +11666,7 @@
 			(at 3.2625 0 90)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "0e5a7a14-ef05-47e6-a3b7-fdbd1a741d25")
 			(effects
 				(font
@@ -13728,6 +13740,7 @@
 			(at -3.181981 -0.353553 45)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "e0b4e3b1-0a9c-4302-aece-c4eceb5a506d")
 			(effects
 				(font
@@ -14739,6 +14752,7 @@
 			(at -3.535534 0 45)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "14ad766b-c377-4691-bcf2-b8368e1c566f")
 			(effects
 				(font
@@ -16096,6 +16110,7 @@
 			(at 0.141421 -1.131371 135)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "c66c158b-6c27-467e-849e-278abcb9d591")
 			(effects
 				(font
@@ -18890,6 +18905,7 @@
 			(at 3.5 0 0)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "3ade556b-4562-46c4-b0d8-92be062f966d")
 			(effects
 				(font
@@ -20218,6 +20234,7 @@
 			(at -3.5 0 0)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "57320691-f9f4-49d7-b165-fb34a15f0a52")
 			(effects
 				(font
@@ -21440,6 +21457,7 @@
 			(at 0 -1 0)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "90bae286-9620-46e3-a33e-dc670ee029c6")
 			(effects
 				(font
@@ -23002,6 +23020,7 @@
 			(at -3.535534 0 45)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "d1574165-4dc1-40e0-b3bf-f841058b1c72")
 			(effects
 				(font
@@ -23921,6 +23940,7 @@
 			(at -0.5 -1 0)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "5b1673a2-5924-4c36-b34e-19fe4ce9d03e")
 			(effects
 				(font
@@ -27995,6 +28015,7 @@
 			(at -3.535534 0 45)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "9957958c-988d-4e51-9a47-b9078725fbea")
 			(effects
 				(font
@@ -28111,6 +28132,7 @@
 			(at -3.181981 -0.353553 45)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "5172dc23-c3d5-48e3-b3da-d9cc05bff4ac")
 			(effects
 				(font
@@ -29479,6 +29501,7 @@
 			(at -3.5 0 0)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "a048b552-beb5-4a9e-a0c8-7b2bec51d9f0")
 			(effects
 				(font
@@ -30615,6 +30638,7 @@
 			(at 3.2625 0 90)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "bde1aecd-6886-41d4-b1f2-1816950a5194")
 			(effects
 				(font
@@ -31719,6 +31743,7 @@
 			(at -3.535534 0 45)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "8841642f-b839-4e8c-aba1-69a79b57c2b4")
 			(effects
 				(font
@@ -32070,10 +32095,94 @@
 			(justify left bottom)
 		)
 	)
+	(gr_text "GND"
+		(at 105.8 149.5 90)
+		(layer "F.SilkS")
+		(uuid "24b4a913-4f05-4f96-be08-2d4ea6a06603")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "INT1"
+		(at 92.8 87.2 0)
+		(layer "F.SilkS")
+		(uuid "2cc4d360-f8e0-4a42-9d29-410f2407a5ac")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
 	(gr_text "BTN_3"
 		(at 56.5 84 315)
 		(layer "F.SilkS")
 		(uuid "31240c92-f65c-47df-ac4b-8bced7315bae")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "MISO"
+		(at 89.9 89.8 90)
+		(layer "F.SilkS")
+		(uuid "360b600e-3b2f-43a3-8d78-8a6fb0faeebe")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "MOSI"
+		(at 84.6 129.8 90)
+		(layer "F.SilkS")
+		(uuid "36835abe-b9e5-4705-ae67-e490e970982f")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "3V3"
+		(at 105.9 141.1 90)
+		(layer "F.SilkS")
+		(uuid "38037fe3-2ed4-453a-9730-b8964b0a9980")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "INT"
+		(at 84.2 125.1 90)
+		(layer "F.SilkS")
+		(uuid "3aabfb85-3542-4758-890d-b2b1b599214b")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "INT2"
+		(at 85.6 82.1 0)
+		(layer "F.SilkS")
+		(uuid "3ad15816-8d95-421a-a97d-1b1dad40c867")
 		(effects
 			(font
 				(size 1 1)
@@ -32106,6 +32215,54 @@
 			(justify left bottom)
 		)
 	)
+	(gr_text "MOSI"
+		(at 84.5 93.4 45)
+		(layer "F.SilkS")
+		(uuid "4ac060da-2b5f-405c-a2c1-64c7c83b938f")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "MISO"
+		(at 82.1 129.8 90)
+		(layer "F.SilkS")
+		(uuid "4e186ed1-8809-49b8-9bc8-75dfb9aa6457")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "CLK"
+		(at 73.5 129.4 45)
+		(layer "F.SilkS")
+		(uuid "4ff67838-6fdb-499d-9f45-78627c757769")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "IO2"
+		(at 69.2 124.7 45)
+		(layer "F.SilkS")
+		(uuid "56bce64d-0b14-4a30-afc7-e6981049d49e")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
 	(gr_text "BOOT"
 		(at 52 99 270)
 		(layer "F.SilkS")
@@ -32118,10 +32275,34 @@
 			(justify left bottom)
 		)
 	)
+	(gr_text "INT"
+		(at 75.1 137.4 0)
+		(layer "F.SilkS")
+		(uuid "7f39e34d-7168-4c9b-b784-53e3aa952b0d")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
 	(gr_text "BTN_0"
 		(at 62 73 315)
 		(layer "F.SilkS")
 		(uuid "80acd805-8439-4db6-a39a-153cefd7f1b3")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "IO0"
+		(at 72.2 127.6 45)
+		(layer "F.SilkS")
+		(uuid "81b65c24-8461-4280-9679-970702a3327c")
 		(effects
 			(font
 				(size 1 1)
@@ -32146,6 +32327,54 @@
 		(at 68 82.5 0)
 		(layer "F.SilkS")
 		(uuid "906701b1-546f-4996-90dd-19e290b3f853")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "NSS"
+		(at 83 88.8 45)
+		(layer "F.SilkS")
+		(uuid "96eddee2-4afa-44de-ad5a-a01c7ca6a289")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "NSS"
+		(at 78.7 116.1 0)
+		(layer "F.SilkS")
+		(uuid "9e34d06a-8dac-4dd0-837f-f37a0c26a372")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "NSS"
+		(at 79.6 129.8 90)
+		(layer "F.SilkS")
+		(uuid "a18f6489-a815-43e9-a3db-7af00453ccb5")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "MOSI"
+		(at 83 112.2 315)
+		(layer "F.SilkS")
+		(uuid "a62950e4-1698-4b59-959b-b702a8d71c77")
 		(effects
 			(font
 				(size 1 1)
@@ -32190,10 +32419,46 @@
 			(justify left bottom)
 		)
 	)
+	(gr_text "SCK"
+		(at 84.1 90.9 45)
+		(layer "F.SilkS")
+		(uuid "bc0a19cf-31bf-4f7d-acb1-8c7cda6460c7")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
 	(gr_text "LED_1"
 		(at 85.2 72.6 0)
 		(layer "F.SilkS")
 		(uuid "c5554433-4076-4e2a-80e0-e340e5aeef13")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "~{CS}"
+		(at 67.2 128.4 45)
+		(layer "F.SilkS")
+		(uuid "c6f70a34-7433-4268-b127-0aa89b7f3a77")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "IO1"
+		(at 70.7 126.1 45)
+		(layer "F.SilkS")
+		(uuid "d617edda-d3ff-4147-b932-b1272dc3c2fe")
 		(effects
 			(font
 				(size 1 1)
@@ -32230,6 +32495,42 @@
 		(at 95 48 0)
 		(layer "F.SilkS")
 		(uuid "dbe176d8-2590-4c55-9f73-5b0af7416844")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "IO3"
+		(at 67.7 123.2 45)
+		(layer "F.SilkS")
+		(uuid "eb346e14-a2ad-4b49-a79e-e42dc5a86e28")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "SCK"
+		(at 87.1 129.9 90)
+		(layer "F.SilkS")
+		(uuid "f4950962-2b4e-4604-b8be-8f35512e266e")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left bottom)
+		)
+	)
+	(gr_text "SCK"
+		(at 82.6 113.7 315)
+		(layer "F.SilkS")
+		(uuid "fcff25ab-fe5e-4592-8ad4-1194c6b81ebc")
 		(effects
 			(font
 				(size 1 1)
@@ -42193,92 +42494,13 @@
 		(uuid "b50e9bbb-136c-482b-b1ab-bf9a23428e2c")
 	)
 	(zone
-		(net 82)
-		(net_name "/MCU/SPI4_SCK")
-		(layer "F.Cu")
-		(uuid "002126e6-3d24-40c2-8acb-429547411b3b")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30044)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 86.600001 116.294236) (xy 86.900001 116.294236) (xy 86.994236 115.758527) (xy 86.7 115.699)
-				(xy 86.405764 115.758527)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 86.983056 115.756265) (xy 86.990485 115.761265) (xy 86.992259 115.76976) (xy 86.901703 116.284563)
-				(xy 86.896895 116.292117) (xy 86.89018 116.294236) (xy 86.608204 116.294236) (xy 86.599931 116.290809)
-				(xy 86.597205 116.286524) (xy 86.548475 116.152128) (xy 86.410391 115.771288) (xy 86.410792 115.762344)
-				(xy 86.417402 115.756303) (xy 86.419056 115.755837) (xy 86.697682 115.699469) (xy 86.702318 115.699469)
-			)
-		)
-	)
-	(zone
-		(net 107)
-		(net_name "/MCU/SPI1_NSS")
-		(layer "F.Cu")
-		(uuid "0165a68c-f8bd-43bd-8ba3-b2febe686bc2")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30025)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 78.85 127.094236) (xy 79.15 127.094236) (xy 79.294236 126.558527) (xy 79 126.499) (xy 78.705764 126.558527)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 79.282017 126.556055) (xy 79.289445 126.561054) (xy 79.291164 126.569842) (xy 79.290994 126.570564)
-				(xy 79.152331 127.085578) (xy 79.146871 127.092676) (xy 79.141033 127.094236) (xy 78.858967 127.094236)
-				(xy 78.850694 127.090809) (xy 78.847669 127.085578) (xy 78.709005 126.570564) (xy 78.710163 126.561684)
-				(xy 78.717261 126.556224) (xy 78.717953 126.55606) (xy 78.997682 126.499469) (xy 79.002318 126.499469)
-			)
-		)
-	)
-	(zone
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "01f80ce3-ec66-4d34-a49e-82a62cce7cee")
+		(uuid "00c0ab53-d5e6-42d5-a038-252b077d5f67")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30113)
+		(priority 30074)
 		(attr
 			(teardrop
 				(type padvia)
@@ -42297,15 +42519,52 @@
 		)
 		(polygon
 			(pts
-				(xy 85.177235 117.35) (xy 85.177235 117.65) (xy 85.710016 117.859832) (xy 85.769543 117.565596)
-				(xy 85.710016 117.27136)
+				(xy 86.55 67.294236) (xy 86.85 67.294236) (xy 86.994236 66.758527) (xy 86.7 66.699) (xy 86.405764 66.758527)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 85.769543 117.565596) (xy 85.710016 117.859832) (xy 85.177235 117.65) (xy 85.177235 117.35)
-				(xy 85.710016 117.27136)
+				(xy 86.994236 66.758527) (xy 86.85 67.294236) (xy 86.55 67.294236) (xy 86.405764 66.758527) (xy 86.7 66.699)
+			)
+		)
+	)
+	(zone
+		(net 109)
+		(net_name "/MCU/SPI1_MISO")
+		(layer "F.Cu")
+		(uuid "03681e48-1c2d-4489-a65d-959a08665c9a")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30022)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 80.35 117.894236) (xy 80.65 117.894236) (xy 80.794236 117.358527) (xy 80.5 117.299) (xy 80.205764 117.358527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 80.782017 117.356055) (xy 80.789445 117.361054) (xy 80.791164 117.369842) (xy 80.790994 117.370564)
+				(xy 80.652331 117.885578) (xy 80.646871 117.892676) (xy 80.641033 117.894236) (xy 80.358967 117.894236)
+				(xy 80.350694 117.890809) (xy 80.347669 117.885578) (xy 80.209005 117.370564) (xy 80.210163 117.361684)
+				(xy 80.217261 117.356224) (xy 80.217953 117.35606) (xy 80.497682 117.299469) (xy 80.502318 117.299469)
 			)
 		)
 	)
@@ -42313,10 +42572,10 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "02034279-ce2f-441e-8411-e8e9f0e8345e")
+		(uuid "04aa92dd-3c14-44af-92bb-bfd0cc52a34e")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30031)
+		(priority 30036)
 		(attr
 			(teardrop
 				(type padvia)
@@ -42335,27 +42594,28 @@
 		)
 		(polygon
 			(pts
-				(xy 57.794236 76.405977) (xy 57.794236 76.105977) (xy 57.258527 76.005764) (xy 57.199 76.3) (xy 57.258527 76.594236)
+				(xy 86.961799 121.805764) (xy 86.661799 121.805764) (xy 86.517563 122.341473) (xy 86.811799 122.401)
+				(xy 87.106035 122.341473)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 57.784688 76.10419) (xy 57.792189 76.10908) (xy 57.794236 76.115691) (xy 57.794236 76.397687)
-				(xy 57.790809 76.40596) (xy 57.786415 76.408725) (xy 57.271208 76.589779) (xy 57.262267 76.589289)
-				(xy 57.256291 76.58262) (xy 57.255863 76.581068) (xy 57.199469 76.302318) (xy 57.199469 76.29768)
-				(xy 57.256241 76.017062) (xy 57.26124 76.009635) (xy 57.269856 76.007883)
+				(xy 86.961105 121.809191) (xy 86.96413 121.814422) (xy 87.102793 122.329435) (xy 87.101635 122.338315)
+				(xy 87.094537 122.343775) (xy 87.093815 122.343945) (xy 86.814119 122.40053) (xy 86.809479 122.40053)
+				(xy 86.529782 122.343945) (xy 86.522353 122.338945) (xy 86.520634 122.330157) (xy 86.520804 122.329435)
+				(xy 86.659468 121.814422) (xy 86.664928 121.807324) (xy 86.670766 121.805764) (xy 86.952832 121.805764)
 			)
 		)
 	)
 	(zone
-		(net 3)
-		(net_name "GND")
+		(net 109)
+		(net_name "/MCU/SPI1_MISO")
 		(layer "F.Cu")
-		(uuid "029bd018-d3fb-4c6b-ac2e-e4f5571f0d38")
+		(uuid "04f05f1f-60da-436d-bde8-bb6a87162a98")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30015)
+		(priority 30134)
 		(attr
 			(teardrop
 				(type padvia)
@@ -42374,26 +42634,28 @@
 		)
 		(polygon
 			(pts
-				(xy 85.096964 55.956589) (xy 84.743411 55.603036) (xy 84.333329 55.950559) (xy 84.499293 56.200707)
-				(xy 84.749441 56.366671)
+				(xy 77.281358 114.226081) (xy 77.069226 114.438213) (xy 77.533329 114.749441) (xy 77.700707 114.500707)
+				(xy 77.641473 114.205764)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 85.096964 55.956589) (xy 84.749441 56.366671) (xy 84.499293 56.200707) (xy 84.333329 55.950559)
-				(xy 84.743411 55.603036)
+				(xy 77.639794 114.20929) (xy 77.643471 114.215712) (xy 77.699745 114.49592) (xy 77.698014 114.504706)
+				(xy 77.697981 114.504756) (xy 77.53985 114.73975) (xy 77.532388 114.744701) (xy 77.523627 114.742935)
+				(xy 77.081046 114.446139) (xy 77.076083 114.438685) (xy 77.077845 114.429906) (xy 77.079284 114.428154)
+				(xy 77.278202 114.229236) (xy 77.285813 114.225829) (xy 77.631342 114.206335)
 			)
 		)
 	)
 	(zone
-		(net 107)
-		(net_name "/MCU/SPI1_NSS")
+		(net 1)
+		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "03f7db6d-fdc2-4157-b5f5-da347557f1ac")
+		(uuid "07b98ead-991a-4745-84b5-83cb626bb676")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30026)
+		(priority 30032)
 		(attr
 			(teardrop
 				(type padvia)
@@ -42412,27 +42674,27 @@
 		)
 		(polygon
 			(pts
-				(xy 76.65 120.405764) (xy 76.35 120.405764) (xy 76.205764 120.941473) (xy 76.5 121.001) (xy 76.794236 120.941473)
+				(xy 87.5 83.605764) (xy 87.2 83.605764) (xy 87.105764 84.141473) (xy 87.4 84.201) (xy 87.694236 84.141473)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 76.649306 120.409191) (xy 76.652331 120.414422) (xy 76.790994 120.929435) (xy 76.789836 120.938315)
-				(xy 76.782738 120.943775) (xy 76.782016 120.943945) (xy 76.50232 121.00053) (xy 76.49768 121.00053)
-				(xy 76.217983 120.943945) (xy 76.210554 120.938945) (xy 76.208835 120.930157) (xy 76.209005 120.929435)
-				(xy 76.347669 120.414422) (xy 76.353129 120.407324) (xy 76.358967 120.405764) (xy 76.641033 120.405764)
+				(xy 87.50007 83.609191) (xy 87.502796 83.613476) (xy 87.689608 84.128709) (xy 87.689207 84.137655)
+				(xy 87.682597 84.143696) (xy 87.680929 84.144165) (xy 87.40232 84.20053) (xy 87.39768 84.20053)
+				(xy 87.116943 84.143734) (xy 87.109514 84.138734) (xy 87.10774 84.130239) (xy 87.198298 83.615437)
+				(xy 87.203106 83.607883) (xy 87.209821 83.605764) (xy 87.491797 83.605764)
 			)
 		)
 	)
 	(zone
-		(net 114)
-		(net_name "/MCU/IMU_INT1")
+		(net 1)
+		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "05a76cf9-7b90-4c61-9443-be21b455bd7a")
+		(uuid "07ead001-139d-4aaf-8270-4a11c1072d92")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30020)
+		(priority 30004)
 		(attr
 			(teardrop
 				(type padvia)
@@ -42451,27 +42713,27 @@
 		)
 		(polygon
 			(pts
-				(xy 83.35 100.594236) (xy 83.65 100.594236) (xy 83.794236 100.058527) (xy 83.5 99.999) (xy 83.205764 100.058527)
+				(xy 107.75 137.794236) (xy 108.25 137.794236) (xy 108.294236 137.258527) (xy 108 137.199) (xy 107.705764 137.258527)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 83.782017 100.056055) (xy 83.789445 100.061054) (xy 83.791164 100.069842) (xy 83.790994 100.070564)
-				(xy 83.652331 100.585578) (xy 83.646871 100.592676) (xy 83.641033 100.594236) (xy 83.358967 100.594236)
-				(xy 83.350694 100.590809) (xy 83.347669 100.585578) (xy 83.209005 100.070564) (xy 83.210163 100.061684)
-				(xy 83.217261 100.056224) (xy 83.217953 100.05606) (xy 83.497682 99.999469) (xy 83.502318 99.999469)
+				(xy 108.284039 137.256464) (xy 108.291468 137.261464) (xy 108.293379 137.268895) (xy 108.250887 137.783499)
+				(xy 108.246791 137.791462) (xy 108.239227 137.794236) (xy 107.760773 137.794236) (xy 107.7525 137.790809)
+				(xy 107.749113 137.783499) (xy 107.70662 137.268895) (xy 107.709354 137.260368) (xy 107.715959 137.256464)
+				(xy 107.997682 137.199469) (xy 108.002318 137.199469)
 			)
 		)
 	)
 	(zone
-		(net 3)
-		(net_name "GND")
+		(net 75)
+		(net_name "/MCU/IMU_INT2")
 		(layer "F.Cu")
-		(uuid "0d0e1b56-ad58-4872-b3d3-a41e39f125a3")
+		(uuid "0b3d8944-9d1b-4283-85ad-d32df2e839aa")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30111)
+		(priority 30057)
 		(attr
 			(teardrop
 				(type padvia)
@@ -42490,15 +42752,16 @@
 		)
 		(polygon
 			(pts
-				(xy 70.399066 112.131443) (xy 70.611198 112.343575) (xy 71.09199 112.066762) (xy 70.926026 111.816614)
-				(xy 70.675878 111.65065)
+				(xy 91.6 82.844237) (xy 91.9 82.844237) (xy 92.044236 82.308528) (xy 91.75 82.249001) (xy 91.455764 82.308528)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 70.926026 111.816614) (xy 71.09199 112.066762) (xy 70.611198 112.343575) (xy 70.399066 112.131443)
-				(xy 70.675878 111.65065)
+				(xy 92.032017 82.306056) (xy 92.039445 82.311055) (xy 92.041164 82.319843) (xy 92.040994 82.320565)
+				(xy 91.902331 82.835579) (xy 91.896871 82.842677) (xy 91.891033 82.844237) (xy 91.608967 82.844237)
+				(xy 91.600694 82.84081) (xy 91.597669 82.835579) (xy 91.459005 82.320565) (xy 91.460163 82.311685)
+				(xy 91.467261 82.306225) (xy 91.467953 82.306061) (xy 91.747682 82.24947) (xy 91.752318 82.24947)
 			)
 		)
 	)
@@ -42506,10 +42769,10 @@
 		(net 56)
 		(net_name "/Flash/~{CS}")
 		(layer "F.Cu")
-		(uuid "0d4b2a4e-3070-4bb6-93ff-7534312a770c")
+		(uuid "10d16f28-ccc2-4fdc-a18d-ec64bca54a9d")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30085)
+		(priority 30098)
 		(attr
 			(teardrop
 				(type padvia)
@@ -42528,17 +42791,17 @@
 		)
 		(polygon
 			(pts
-				(xy 72.273746 122.014122) (xy 72.485879 122.226254) (xy 72.966671 121.949441) (xy 72.800707 121.699293)
-				(xy 72.550559 121.533329)
+				(xy 73.826254 111.885878) (xy 73.614122 111.673746) (xy 73.133329 111.950559) (xy 73.299293 112.200707)
+				(xy 73.549441 112.366671)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 72.560317 121.53983) (xy 72.560947 121.540221) (xy 72.798734 121.697984) (xy 72.802015 121.701265)
-				(xy 72.959778 121.939052) (xy 72.961497 121.94784) (xy 72.956497 121.955269) (xy 72.955867 121.95566)
-				(xy 72.493649 122.22178) (xy 72.484769 122.222938) (xy 72.479538 122.219913) (xy 72.280086 122.020462)
-				(xy 72.276659 122.012189) (xy 72.278218 122.006354) (xy 72.544339 121.544131) (xy 72.551437 121.538672)
+				(xy 73.620462 111.680086) (xy 73.819913 111.879537) (xy 73.82334 111.88781) (xy 73.82178 111.893648)
+				(xy 73.55566 112.355867) (xy 73.548562 112.361327) (xy 73.539682 112.360169) (xy 73.539052 112.359778)
+				(xy 73.301265 112.202015) (xy 73.297984 112.198734) (xy 73.140221 111.960947) (xy 73.138502 111.952159)
+				(xy 73.143502 111.94473) (xy 73.144132 111.944339) (xy 73.606353 111.678218) (xy 73.615231 111.677061)
 			)
 		)
 	)
@@ -42546,10 +42809,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "0d8e39a2-f802-4717-bc91-bd2a0b6ad3e8")
+		(uuid "131acf90-f045-4eba-ae0e-b8a57dc7cf43")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30001)
+		(priority 30069)
 		(attr
 			(teardrop
 				(type padvia)
@@ -42568,15 +42831,91 @@
 		)
 		(polygon
 			(pts
-				(xy 82.699999 146.005764) (xy 82.199999 146.005764) (xy 82.205764 146.658527) (xy 82.5 146.601)
-				(xy 82.794236 146.541473)
+				(xy 81.694236 137.4125) (xy 81.694236 137.1125) (xy 81.158527 137.005764) (xy 81.099 137.3) (xy 81.158527 137.594236)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 82.794236 146.541473) (xy 82.5 146.601) (xy 82.205764 146.658527) (xy 82.199999 146.005764)
-				(xy 82.699999 146.005764)
+				(xy 81.694236 137.1125) (xy 81.694236 137.4125) (xy 81.158527 137.594236) (xy 81.099 137.3) (xy 81.158527 137.005764)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "153264ce-6e46-43e0-b5e0-775456fdbd55")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30138)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 48.700624 108.850481) (xy 48.400624 108.850481) (xy 48.605764 109.358527) (xy 48.9 109.301)
+				(xy 49.066671 109.050559)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 49.066671 109.050559) (xy 48.9 109.301) (xy 48.605764 109.358527) (xy 48.400624 108.850481)
+				(xy 48.700624 108.850481)
+			)
+		)
+	)
+	(zone
+		(net 85)
+		(net_name "/MCU/SPI2_SCK")
+		(layer "F.Cu")
+		(uuid "17c36be7-7724-4b57-b360-93aa7fc40a8e")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30102)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 86.473746 100.314122) (xy 86.685878 100.526254) (xy 87.166671 100.249441) (xy 87.000707 99.999293)
+				(xy 86.750559 99.833329)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 86.760317 99.83983) (xy 86.760947 99.840221) (xy 86.998734 99.997984) (xy 87.002015 100.001265)
+				(xy 87.159778 100.239052) (xy 87.161497 100.24784) (xy 87.156497 100.255269) (xy 87.155867 100.25566)
+				(xy 86.693648 100.52178) (xy 86.684768 100.522938) (xy 86.679537 100.519913) (xy 86.480086 100.320462)
+				(xy 86.476659 100.312189) (xy 86.478218 100.306354) (xy 86.744339 99.844131) (xy 86.751437 99.838672)
 			)
 		)
 	)
@@ -42584,10 +42923,10 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "0da24795-9128-4fb1-9daf-fe958c147805")
+		(uuid "18b9a982-c3ad-4ee2-852b-e98b425a8c79")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30008)
+		(priority 30007)
 		(attr
 			(teardrop
 				(type padvia)
@@ -42606,288 +42945,16 @@
 		)
 		(polygon
 			(pts
-				(xy 94.75 138.505764) (xy 94.25 138.505764) (xy 94.205764 139.041473) (xy 94.5 139.101) (xy 94.794236 139.041473)
+				(xy 108.705764 137.75) (xy 108.705764 138.25) (xy 109.241473 138.294236) (xy 109.301 138) (xy 109.241473 137.705764)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 94.7475 138.509191) (xy 94.750887 138.516501) (xy 94.793379 139.031104) (xy 94.790645 139.039631)
-				(xy 94.784039 139.043535) (xy 94.50232 139.10053) (xy 94.49768 139.10053) (xy 94.21596 139.043535)
-				(xy 94.208531 139.038535) (xy 94.20662 139.031104) (xy 94.249113 138.516501) (xy 94.253209 138.508538)
-				(xy 94.260773 138.505764) (xy 94.739227 138.505764)
-			)
-		)
-	)
-	(zone
-		(net 59)
-		(net_name "/MCU/BUZZER")
-		(layer "F.Cu")
-		(uuid "10fc0e93-661d-418e-ab3a-ea7d8a7d4f60")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30060)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 73.85 129.694236) (xy 74.15 129.694236) (xy 74.294236 129.158527) (xy 74 129.099) (xy 73.705764 129.158527)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 74.282017 129.156055) (xy 74.289445 129.161054) (xy 74.291164 129.169842) (xy 74.290994 129.170564)
-				(xy 74.152331 129.685578) (xy 74.146871 129.692676) (xy 74.141033 129.694236) (xy 73.858967 129.694236)
-				(xy 73.850694 129.690809) (xy 73.847669 129.685578) (xy 73.709005 129.170564) (xy 73.710163 129.161684)
-				(xy 73.717261 129.156224) (xy 73.717953 129.15606) (xy 73.997682 129.099469) (xy 74.002318 129.099469)
-			)
-		)
-	)
-	(zone
-		(net 108)
-		(net_name "/MCU/MAG_INT")
-		(layer "F.Cu")
-		(uuid "117414a2-1918-428e-8949-4007656e5bed")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30109)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 85.851676 119.288699) (xy 86.063808 119.076567) (xy 85.786996 118.595774) (xy 85.536848 118.761738)
-				(xy 85.370884 119.011886)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 85.792824 118.605947) (xy 85.793215 118.606577) (xy 86.059334 119.068796) (xy 86.060492 119.077676)
-				(xy 86.057467 119.082907) (xy 85.858016 119.282358) (xy 85.849743 119.285785) (xy 85.843905 119.284225)
-				(xy 85.381687 119.018105) (xy 85.376227 119.011007) (xy 85.377385 119.002127) (xy 85.377765 119.001513)
-				(xy 85.53554 118.763708) (xy 85.538818 118.76043) (xy 85.776608 118.602665) (xy 85.785395 118.600947)
-			)
-		)
-	)
-	(zone
-		(net 31)
-		(net_name "/MCU/SERVO_SIG")
-		(layer "F.Cu")
-		(uuid "133a12e4-0fe4-49d1-9806-abd7587f7c12")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30058)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 62.35 97.094236) (xy 62.65 97.094236) (xy 62.794236 96.558527) (xy 62.5 96.499) (xy 62.205764 96.558527)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 62.782017 96.556055) (xy 62.789445 96.561054) (xy 62.791164 96.569842) (xy 62.790994 96.570564)
-				(xy 62.652331 97.085578) (xy 62.646871 97.092676) (xy 62.641033 97.094236) (xy 62.358967 97.094236)
-				(xy 62.350694 97.090809) (xy 62.347669 97.085578) (xy 62.209005 96.570564) (xy 62.210163 96.561684)
-				(xy 62.217261 96.556224) (xy 62.217953 96.55606) (xy 62.497682 96.499469) (xy 62.502318 96.499469)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "14e737c6-65ac-44b7-b509-379ffd6dec18")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30054)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 83.65 119.105764) (xy 83.35 119.105764) (xy 83.205764 119.641473) (xy 83.5 119.701) (xy 83.794236 119.641473)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 83.794236 119.641473) (xy 83.5 119.701) (xy 83.205764 119.641473) (xy 83.35 119.105764) (xy 83.65 119.105764)
-			)
-		)
-	)
-	(zone
-		(net 57)
-		(net_name "/MCU/SERVO_EN")
-		(layer "F.Cu")
-		(uuid "15911fcd-e646-4a23-ad3e-8951211caf1c")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30073)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 61.75 86.405764) (xy 61.45 86.405764) (xy 61.305764 86.941473) (xy 61.6 87.001) (xy 61.894236 86.941473)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 61.749306 86.409191) (xy 61.752331 86.414422) (xy 61.890994 86.929435) (xy 61.889836 86.938315)
-				(xy 61.882738 86.943775) (xy 61.882016 86.943945) (xy 61.60232 87.00053) (xy 61.59768 87.00053)
-				(xy 61.317983 86.943945) (xy 61.310554 86.938945) (xy 61.308835 86.930157) (xy 61.309005 86.929435)
-				(xy 61.447669 86.414422) (xy 61.453129 86.407324) (xy 61.458967 86.405764) (xy 61.741033 86.405764)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "16e8d08a-ed93-4f7d-bc21-af65720cc2ac")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30112)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 64.60079 103.666833) (xy 64.388658 103.878965) (xy 64.665471 104.359757) (xy 64.915619 104.193793)
-				(xy 65.081583 103.943645)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 65.081583 103.943645) (xy 64.915619 104.193793) (xy 64.665471 104.359757) (xy 64.388658 103.878965)
-				(xy 64.60079 103.666833)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "186d17e6-f4e1-4088-a4ee-9af672d82bb5")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30087)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 70.185878 134.973746) (xy 69.973746 135.185878) (xy 70.250559 135.666671) (xy 70.500707 135.500707)
-				(xy 70.666671 135.250559)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 70.193646 134.978218) (xy 70.478798 135.142392) (xy 70.655867 135.244339) (xy 70.661327 135.251437)
-				(xy 70.660169 135.260317) (xy 70.659778 135.260947) (xy 70.502015 135.498734) (xy 70.498734 135.502015)
-				(xy 70.260947 135.659778) (xy 70.252159 135.661497) (xy 70.24473 135.656497) (xy 70.244339 135.655867)
-				(xy 70.016966 135.260947) (xy 69.978218 135.193646) (xy 69.977061 135.184768) (xy 69.980084 135.179539)
-				(xy 70.179538 134.980085) (xy 70.18781 134.976659)
+				(xy 109.239631 137.709354) (xy 109.243535 137.71596) (xy 109.30053 137.99768) (xy 109.30053 138.00232)
+				(xy 109.243535 138.284039) (xy 109.238535 138.291468) (xy 109.231104 138.293379) (xy 108.716501 138.250886)
+				(xy 108.708538 138.24679) (xy 108.705764 138.239226) (xy 108.705764 137.760773) (xy 108.709191 137.7525)
+				(xy 108.716499 137.749113) (xy 109.231104 137.70662)
 			)
 		)
 	)
@@ -42939,13 +43006,13 @@
 		)
 	)
 	(zone
-		(net 57)
-		(net_name "/MCU/SERVO_EN")
+		(net 1)
+		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "18fe92d4-c4d4-4e54-8d9a-0d1c811f1925")
+		(uuid "19facd93-054d-43fd-b062-9617569b7702")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30063)
+		(priority 30005)
 		(attr
 			(teardrop
 				(type padvia)
@@ -42964,16 +43031,16 @@
 		)
 		(polygon
 			(pts
-				(xy 61.45 97.094236) (xy 61.75 97.094236) (xy 61.894236 96.558527) (xy 61.6 96.499) (xy 61.305764 96.558527)
+				(xy 108.25 142.205764) (xy 107.75 142.205764) (xy 107.705764 142.741473) (xy 108 142.801) (xy 108.294236 142.741473)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 61.882017 96.556055) (xy 61.889445 96.561054) (xy 61.891164 96.569842) (xy 61.890994 96.570564)
-				(xy 61.752331 97.085578) (xy 61.746871 97.092676) (xy 61.741033 97.094236) (xy 61.458967 97.094236)
-				(xy 61.450694 97.090809) (xy 61.447669 97.085578) (xy 61.309005 96.570564) (xy 61.310163 96.561684)
-				(xy 61.317261 96.556224) (xy 61.317953 96.55606) (xy 61.597682 96.499469) (xy 61.602318 96.499469)
+				(xy 108.2475 142.209191) (xy 108.250887 142.216501) (xy 108.293379 142.731104) (xy 108.290645 142.739631)
+				(xy 108.284039 142.743535) (xy 108.00232 142.80053) (xy 107.99768 142.80053) (xy 107.71596 142.743535)
+				(xy 107.708531 142.738535) (xy 107.70662 142.731104) (xy 107.749113 142.216501) (xy 107.753209 142.208538)
+				(xy 107.760773 142.205764) (xy 108.239227 142.205764)
 			)
 		)
 	)
@@ -42981,10 +43048,10 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "19e553a3-d3e7-496f-8f41-d0668fe12a19")
+		(uuid "21854898-515a-4851-9422-d2c815c1af89")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30123)
+		(priority 30088)
 		(attr
 			(teardrop
 				(type padvia)
@@ -43003,18 +43070,58 @@
 		)
 		(polygon
 			(pts
-				(xy 83.149999 136.816113) (xy 83.449999 136.816113) (xy 83.394236 136.241473) (xy 83.1 136.299)
-				(xy 82.850559 136.466671)
+				(xy 54.285878 73.973746) (xy 54.073746 74.185878) (xy 54.350559 74.666671) (xy 54.600707 74.500707)
+				(xy 54.766671 74.250559)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 83.390367 136.245721) (xy 83.395318 136.253183) (xy 83.39548 136.254298) (xy 83.448754 136.803283)
-				(xy 83.446143 136.811848) (xy 83.438239 136.816058) (xy 83.437109 136.816113) (xy 83.155381 136.816113)
-				(xy 83.147108 136.812686) (xy 83.146497 136.812026) (xy 82.859116 136.476657) (xy 82.856335 136.468145)
-				(xy 82.860387 136.46016) (xy 82.861464 136.45934) (xy 83.09804 136.300317) (xy 83.102314 136.298547)
-				(xy 83.381591 136.243945)
+				(xy 54.293646 73.978218) (xy 54.578798 74.142392) (xy 54.755867 74.244339) (xy 54.761327 74.251437)
+				(xy 54.760169 74.260317) (xy 54.759778 74.260947) (xy 54.602015 74.498734) (xy 54.598734 74.502015)
+				(xy 54.360947 74.659778) (xy 54.352159 74.661497) (xy 54.34473 74.656497) (xy 54.344339 74.655867)
+				(xy 54.116966 74.260947) (xy 54.078218 74.193646) (xy 54.077061 74.184768) (xy 54.080084 74.179539)
+				(xy 54.279538 73.980085) (xy 54.28781 73.976659)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "22399e50-f8ab-4539-8dc5-d7df87778653")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30018)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 86.900001 118.205764) (xy 86.600001 118.205764) (xy 86.505764 118.741473) (xy 86.8 118.801)
+				(xy 87.094236 118.741473)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 86.900071 118.209191) (xy 86.902797 118.213476) (xy 87.089608 118.728709) (xy 87.089207 118.737655)
+				(xy 87.082597 118.743696) (xy 87.080929 118.744165) (xy 86.80232 118.80053) (xy 86.79768 118.80053)
+				(xy 86.516943 118.743734) (xy 86.509514 118.738734) (xy 86.50774 118.730239) (xy 86.598299 118.215437)
+				(xy 86.603107 118.207883) (xy 86.609822 118.205764) (xy 86.891798 118.205764)
 			)
 		)
 	)
@@ -43022,10 +43129,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "1af638f1-d926-4377-91d0-9070384f2beb")
+		(uuid "29901bc1-f7ec-413a-b820-8b469099a82f")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30080)
+		(priority 30128)
 		(attr
 			(teardrop
 				(type padvia)
@@ -43044,13 +43151,14 @@
 		)
 		(polygon
 			(pts
-				(xy 48.794236 97.15) (xy 48.794236 96.85) (xy 48.258527 96.705764) (xy 48.199 97) (xy 48.258527 97.294236)
+				(xy 85.6 118.0882) (xy 85.9 118.0882) (xy 86.062779 117.624123) (xy 85.768543 117.564596) (xy 85.474307 117.624123)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 48.794236 96.85) (xy 48.794236 97.15) (xy 48.258527 97.294236) (xy 48.199 97) (xy 48.258527 96.705764)
+				(xy 86.062779 117.624123) (xy 85.983937 117.848897) (xy 85.977531 117.858486) (xy 85.973544 117.878526)
+				(xy 85.9 118.0882) (xy 85.6 118.0882) (xy 85.474307 117.624123) (xy 85.768543 117.564596)
 			)
 		)
 	)
@@ -43058,10 +43166,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "1b384637-f818-4135-924f-8bf3e7abb1a8")
+		(uuid "2a1ec663-377f-4bfc-a81f-30ea0c2eb27f")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30068)
+		(priority 30034)
 		(attr
 			(teardrop
 				(type padvia)
@@ -43080,13 +43188,284 @@
 		)
 		(polygon
 			(pts
-				(xy 81.694236 139.1125) (xy 81.694236 138.8125) (xy 81.158527 138.705764) (xy 81.099 139) (xy 81.158527 139.294236)
+				(xy 76.85 92.394236) (xy 77.15 92.394236) (xy 77.294236 91.858527) (xy 77 91.799) (xy 76.705764 91.858527)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 81.694236 138.8125) (xy 81.694236 139.1125) (xy 81.158527 139.294236) (xy 81.099 139) (xy 81.158527 138.705764)
+				(xy 77.294236 91.858527) (xy 77.15 92.394236) (xy 76.85 92.394236) (xy 76.705764 91.858527) (xy 77 91.799)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "2a757b96-d10c-47ed-9226-eda1f989bd5c")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30013)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 86.156589 108.803036) (xy 85.803036 109.156589) (xy 86.150559 109.566671) (xy 86.400707 109.400707)
+				(xy 86.566671 109.150559)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 86.566671 109.150559) (xy 86.400707 109.400707) (xy 86.150559 109.566671) (xy 85.803036 109.156589)
+				(xy 86.156589 108.803036)
+			)
+		)
+	)
+	(zone
+		(net 75)
+		(net_name "/MCU/IMU_INT2")
+		(layer "F.Cu")
+		(uuid "2ab3c14a-65ef-4295-8ef3-aa218682e5b3")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30051)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 82.35 100.594236) (xy 82.65 100.594236) (xy 82.794236 100.058527) (xy 82.5 99.999) (xy 82.205764 100.058527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 82.782017 100.056055) (xy 82.789445 100.061054) (xy 82.791164 100.069842) (xy 82.790994 100.070564)
+				(xy 82.652331 100.585578) (xy 82.646871 100.592676) (xy 82.641033 100.594236) (xy 82.358967 100.594236)
+				(xy 82.350694 100.590809) (xy 82.347669 100.585578) (xy 82.209005 100.070564) (xy 82.210163 100.061684)
+				(xy 82.217261 100.056224) (xy 82.217953 100.05606) (xy 82.497682 99.999469) (xy 82.502318 99.999469)
+			)
+		)
+	)
+	(zone
+		(net 81)
+		(net_name "/MCU/SPI4_NSS")
+		(layer "F.Cu")
+		(uuid "2cf38e70-0924-4425-a06e-df2c20be1ff6")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30047)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 84.005764 114.35) (xy 84.005764 114.65) (xy 84.541473 114.794236) (xy 84.601 114.5) (xy 84.541473 114.205764)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 84.538315 114.210163) (xy 84.543775 114.217261) (xy 84.543945 114.217983) (xy 84.60053 114.49768)
+				(xy 84.60053 114.50232) (xy 84.543945 114.782016) (xy 84.538945 114.789445) (xy 84.530157 114.791164)
+				(xy 84.529435 114.790994) (xy 84.014422 114.652331) (xy 84.007324 114.646871) (xy 84.005764 114.641033)
+				(xy 84.005764 114.358966) (xy 84.009191 114.350693) (xy 84.014419 114.347669) (xy 84.529435 114.209005)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "2d04c094-cbdf-4d8f-bcbd-ff9d3fc0fb72")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30050)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 92.805764 83.850001) (xy 92.805764 84.150001) (xy 93.341473 84.294237) (xy 93.401 84.000001)
+				(xy 93.341473 83.705765)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 93.401 84.000001) (xy 93.341473 84.294237) (xy 92.805764 84.150001) (xy 92.805764 83.850001)
+				(xy 93.341473 83.705765)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "2e9e6edd-24ff-4c31-9f6c-aa01e97baf5a")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30122)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 54.585636 84.670712) (xy 54.585636 84.370712) (xy 54.058527 84.305764) (xy 53.999 84.6) (xy 54.166671 84.849441)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 54.575368 84.369446) (xy 54.583159 84.373859) (xy 54.585636 84.381058) (xy 54.585636 84.662982)
+				(xy 54.582209 84.671255) (xy 54.578527 84.673744) (xy 54.175572 84.845643) (xy 54.166618 84.845737)
+				(xy 54.161271 84.841408) (xy 54.001727 84.604057) (xy 53.999956 84.595279) (xy 53.999969 84.59521)
+				(xy 54.043294 84.381058) (xy 54.056379 84.316379) (xy 54.061379 84.308951) (xy 54.069276 84.307088)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "2fd23e50-5713-4bd7-bf39-d818555cbef7")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30120)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 86.65 112.85) (xy 86.95 112.85) (xy 87.094236 112.358527) (xy 86.8 112.299) (xy 86.505764 112.358527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 87.081739 112.355998) (xy 87.089167 112.360998) (xy 87.090886 112.369786) (xy 87.090645 112.370761)
+				(xy 86.952467 112.841595) (xy 86.946849 112.848568) (xy 86.94124 112.85) (xy 86.65876 112.85) (xy 86.650487 112.846573)
+				(xy 86.647533 112.841595) (xy 86.509354 112.370761) (xy 86.510313 112.361857) (xy 86.517286 112.356239)
+				(xy 86.518244 112.356002) (xy 86.797682 112.299469) (xy 86.802318 112.299469)
+			)
+		)
+	)
+	(zone
+		(net 87)
+		(net_name "/MCU/BATT_ISENSE")
+		(layer "F.Cu")
+		(uuid "30e60a00-ace0-45bf-85da-97a96f93f461")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30030)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 77.85 103.094236) (xy 78.15 103.094236) (xy 78.294236 102.558527) (xy 78 102.499) (xy 77.705764 102.558527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 78.282017 102.556055) (xy 78.289445 102.561054) (xy 78.291164 102.569842) (xy 78.290994 102.570564)
+				(xy 78.152331 103.085578) (xy 78.146871 103.092676) (xy 78.141033 103.094236) (xy 77.858967 103.094236)
+				(xy 77.850694 103.090809) (xy 77.847669 103.085578) (xy 77.709005 102.570564) (xy 77.710163 102.561684)
+				(xy 77.717261 102.556224) (xy 77.717953 102.55606) (xy 77.997682 102.499469) (xy 78.002318 102.499469)
 			)
 		)
 	)
@@ -43094,7 +43473,7 @@
 		(net 13)
 		(net_name "/MCU/BATT_VSENSE")
 		(layer "F.Cu")
-		(uuid "1c1be3c8-0549-434c-9d58-646c9a4b7c86")
+		(uuid "319a3d78-fecd-4e00-a045-92ab3a47e9bb")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30097)
@@ -43131,13 +43510,13 @@
 		)
 	)
 	(zone
-		(net 55)
-		(net_name "/Flash/IO3")
+		(net 1)
+		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "2146dfe1-7f17-482f-8c7a-509a8559e62d")
+		(uuid "33304c1b-7df3-451a-aea6-8dfa82f993e9")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30114)
+		(priority 30039)
 		(attr
 			(teardrop
 				(type padvia)
@@ -43156,28 +43535,28 @@
 		)
 		(polygon
 			(pts
-				(xy 62.47129 127.740842) (xy 62.259158 127.52871) (xy 61.833329 127.852533) (xy 61.999293 128.102681)
-				(xy 62.249441 128.268645)
+				(xy 78.294236 134.65) (xy 78.294236 134.35) (xy 77.758527 134.205764) (xy 77.699 134.5) (xy 77.758527 134.794236)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 62.266381 127.535933) (xy 62.46573 127.735282) (xy 62.469157 127.743555) (xy 62.468243 127.748089)
-				(xy 62.254917 128.255616) (xy 62.248552 128.261915) (xy 62.239597 128.261868) (xy 62.237663 128.260831)
-				(xy 62.001265 128.103989) (xy 61.997984 128.100708) (xy 61.839393 127.861673) (xy 61.837674 127.852885)
-				(xy 61.842058 127.845894) (xy 62.251028 127.534892) (xy 62.259686 127.532613)
+				(xy 77.770564 134.209005) (xy 77.80391 134.217983) (xy 78.285579 134.347669) (xy 78.292676 134.353128)
+				(xy 78.294236 134.358966) (xy 78.294236 134.641033) (xy 78.290809 134.649306) (xy 78.285578 134.652331)
+				(xy 77.770564 134.790994) (xy 77.761684 134.789836) (xy 77.756224 134.782738) (xy 77.756059 134.782039)
+				(xy 77.699469 134.502318) (xy 77.699469 134.49768) (xy 77.756055 134.21798) (xy 77.761054 134.210554)
+				(xy 77.769842 134.208835)
 			)
 		)
 	)
 	(zone
-		(net 85)
-		(net_name "/MCU/SPI2_SCK")
+		(net 81)
+		(net_name "/MCU/SPI4_NSS")
 		(layer "F.Cu")
-		(uuid "21bcb281-8998-4ab9-82ff-3c56f8db56b7")
+		(uuid "33c4235d-0587-441e-b356-17e34257b6d0")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30033)
+		(priority 30046)
 		(attr
 			(teardrop
 				(type padvia)
@@ -43196,135 +43575,17 @@
 		)
 		(polygon
 			(pts
-				(xy 85.65 97.905764) (xy 85.35 97.905764) (xy 85.205764 98.441473) (xy 85.5 98.501) (xy 85.794236 98.441473)
+				(xy 86.494236 114.65) (xy 86.494236 114.35) (xy 85.958527 114.205764) (xy 85.899 114.5) (xy 85.958527 114.794236)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 85.649306 97.909191) (xy 85.652331 97.914422) (xy 85.790994 98.429435) (xy 85.789836 98.438315)
-				(xy 85.782738 98.443775) (xy 85.782016 98.443945) (xy 85.50232 98.50053) (xy 85.49768 98.50053)
-				(xy 85.217983 98.443945) (xy 85.210554 98.438945) (xy 85.208835 98.430157) (xy 85.209005 98.429435)
-				(xy 85.347669 97.914422) (xy 85.353129 97.907324) (xy 85.358967 97.905764) (xy 85.641033 97.905764)
-			)
-		)
-	)
-	(zone
-		(net 59)
-		(net_name "/MCU/BUZZER")
-		(layer "F.Cu")
-		(uuid "22c32fa5-a9fb-4bd4-a8c7-a9a15276e210")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30084)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 69.685879 105.923494) (xy 69.473746 106.135626) (xy 69.750559 106.616419) (xy 70.000707 106.450455)
-				(xy 70.166671 106.200307)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 69.693647 105.927966) (xy 69.976438 106.090781) (xy 70.155867 106.194087) (xy 70.161327 106.201185)
-				(xy 70.160169 106.210065) (xy 70.159778 106.210695) (xy 70.002015 106.448482) (xy 69.998734 106.451763)
-				(xy 69.760947 106.609526) (xy 69.752159 106.611245) (xy 69.74473 106.606245) (xy 69.744339 106.605615)
-				(xy 69.516966 106.210695) (xy 69.478218 106.143394) (xy 69.477061 106.134516) (xy 69.480084 106.129287)
-				(xy 69.679539 105.929833) (xy 69.687811 105.926407)
-			)
-		)
-	)
-	(zone
-		(net 116)
-		(net_name "/MCU/SPI1_SCK")
-		(layer "F.Cu")
-		(uuid "248d55ef-4bf2-47f0-a458-879294df60a5")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30072)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 77.65 119.905764) (xy 77.35 119.905764) (xy 77.205764 120.441473) (xy 77.5 120.501) (xy 77.794236 120.441473)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 77.649306 119.909191) (xy 77.652331 119.914422) (xy 77.790994 120.429435) (xy 77.789836 120.438315)
-				(xy 77.782738 120.443775) (xy 77.782016 120.443945) (xy 77.50232 120.50053) (xy 77.49768 120.50053)
-				(xy 77.217983 120.443945) (xy 77.210554 120.438945) (xy 77.208835 120.430157) (xy 77.209005 120.429435)
-				(xy 77.347669 119.914422) (xy 77.353129 119.907324) (xy 77.358967 119.905764) (xy 77.641033 119.905764)
-			)
-		)
-	)
-	(zone
-		(net 128)
-		(net_name "/MCU/SERVO_FDBK")
-		(layer "F.Cu")
-		(uuid "25175afd-2a76-4425-b26d-7a8f5c2f4fc4")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30066)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 78.85 103.594236) (xy 79.15 103.594236) (xy 79.294236 103.058527) (xy 79 102.999) (xy 78.705764 103.058527)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 79.282017 103.056055) (xy 79.289445 103.061054) (xy 79.291164 103.069842) (xy 79.290994 103.070564)
-				(xy 79.152331 103.585578) (xy 79.146871 103.592676) (xy 79.141033 103.594236) (xy 78.858967 103.594236)
-				(xy 78.850694 103.590809) (xy 78.847669 103.585578) (xy 78.709005 103.070564) (xy 78.710163 103.061684)
-				(xy 78.717261 103.056224) (xy 78.717953 103.05606) (xy 78.997682 102.999469) (xy 79.002318 102.999469)
+				(xy 85.970564 114.209005) (xy 86.00391 114.217983) (xy 86.485579 114.347669) (xy 86.492676 114.353128)
+				(xy 86.494236 114.358966) (xy 86.494236 114.641033) (xy 86.490809 114.649306) (xy 86.485578 114.652331)
+				(xy 85.970564 114.790994) (xy 85.961684 114.789836) (xy 85.956224 114.782738) (xy 85.956059 114.782039)
+				(xy 85.899469 114.502318) (xy 85.899469 114.49768) (xy 85.956055 114.21798) (xy 85.961054 114.210554)
+				(xy 85.969842 114.208835)
 			)
 		)
 	)
@@ -43332,10 +43593,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "27ffd532-a606-4468-89d1-f3950b892519")
+		(uuid "340182fe-e221-4d53-b353-d7cd36a75a09")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30071)
+		(priority 30094)
 		(attr
 			(teardrop
 				(type padvia)
@@ -43354,24 +43615,26 @@
 		)
 		(polygon
 			(pts
-				(xy 91.9 71.194236) (xy 92.2 71.194236) (xy 92.294236 70.658527) (xy 92 70.599) (xy 91.705764 70.658527)
+				(xy 67.785878 72.173746) (xy 67.573746 72.385878) (xy 67.850559 72.866671) (xy 68.100707 72.700707)
+				(xy 68.266671 72.450559)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 92.294236 70.658527) (xy 92.2 71.194236) (xy 91.9 71.194236) (xy 91.705764 70.658527) (xy 92 70.599)
+				(xy 68.266671 72.450559) (xy 68.100707 72.700707) (xy 67.850559 72.866671) (xy 67.573746 72.385878)
+				(xy 67.785878 72.173746)
 			)
 		)
 	)
 	(zone
-		(net 84)
-		(net_name "/MCU/SPI1_MOSI")
+		(net 108)
+		(net_name "/MCU/MAG_INT")
 		(layer "F.Cu")
-		(uuid "307a31fb-cfb5-464d-9bbd-a42ac2803d3e")
+		(uuid "37f927af-64ce-47bd-88ac-e730718c11fb")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30135)
+		(priority 30136)
 		(attr
 			(teardrop
 				(type padvia)
@@ -43390,17 +43653,56 @@
 		)
 		(polygon
 			(pts
-				(xy 77.268795 113.50641) (xy 77.056663 113.718542) (xy 77.533329 113.999442) (xy 77.700707 113.750708)
-				(xy 77.641473 113.455765)
+				(xy 85.399999 118.287319) (xy 85.099999 118.287319) (xy 85.243319 118.820972) (xy 85.537555 118.763445)
+				(xy 85.704226 118.513004)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 77.639248 113.459525) (xy 77.643635 113.466533) (xy 77.699745 113.745921) (xy 77.698014 113.754707)
-				(xy 77.697981 113.754757) (xy 77.539481 113.990298) (xy 77.532019 113.995249) (xy 77.523834 113.993846)
-				(xy 77.069678 113.726212) (xy 77.06429 113.719059) (xy 77.065538 113.710192) (xy 77.067341 113.707863)
-				(xy 77.266007 113.509197) (xy 77.272701 113.505879) (xy 77.630589 113.457244)
+				(xy 85.403103 118.289622) (xy 85.695297 118.50638) (xy 85.6999 118.514062) (xy 85.698066 118.522259)
+				(xy 85.540259 118.75938) (xy 85.532823 118.764369) (xy 85.532764 118.764381) (xy 85.254032 118.818877)
+				(xy 85.245255 118.817101) (xy 85.240487 118.81043) (xy 85.103956 118.302053) (xy 85.10512 118.293175)
+				(xy 85.112221 118.287719) (xy 85.115256 118.287319) (xy 85.396132 118.287319)
+			)
+		)
+	)
+	(zone
+		(net 114)
+		(net_name "/MCU/IMU_INT1")
+		(layer "F.Cu")
+		(uuid "38209eff-f62a-454d-a8e4-4323098b3111")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30020)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 83.35 100.594236) (xy 83.65 100.594236) (xy 83.794236 100.058527) (xy 83.5 99.999) (xy 83.205764 100.058527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 83.782017 100.056055) (xy 83.789445 100.061054) (xy 83.791164 100.069842) (xy 83.790994 100.070564)
+				(xy 83.652331 100.585578) (xy 83.646871 100.592676) (xy 83.641033 100.594236) (xy 83.358967 100.594236)
+				(xy 83.350694 100.590809) (xy 83.347669 100.585578) (xy 83.209005 100.070564) (xy 83.210163 100.061684)
+				(xy 83.217261 100.056224) (xy 83.217953 100.05606) (xy 83.497682 99.999469) (xy 83.502318 99.999469)
 			)
 		)
 	)
@@ -43408,10 +43710,10 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "324ad196-1708-4bcc-a986-4720ef75c584")
+		(uuid "38d57b15-1383-4874-a568-5b5edd278355")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30062)
+		(priority 30045)
 		(attr
 			(teardrop
 				(type padvia)
@@ -43430,95 +43732,17 @@
 		)
 		(polygon
 			(pts
-				(xy 80.3 55.755764) (xy 80 55.755764) (xy 79.855764 56.291473) (xy 80.15 56.351) (xy 80.444236 56.291473)
+				(xy 86.661799 122.994236) (xy 86.961799 122.994236) (xy 87.106035 122.458527) (xy 86.811799 122.399)
+				(xy 86.517563 122.458527)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 80.299306 55.759191) (xy 80.302331 55.764422) (xy 80.440994 56.279435) (xy 80.439836 56.288315)
-				(xy 80.432738 56.293775) (xy 80.432016 56.293945) (xy 80.15232 56.35053) (xy 80.14768 56.35053)
-				(xy 79.867983 56.293945) (xy 79.860554 56.288945) (xy 79.858835 56.280157) (xy 79.859005 56.279435)
-				(xy 79.997669 55.764422) (xy 80.003129 55.757324) (xy 80.008967 55.755764) (xy 80.291033 55.755764)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "3286152a-7f9d-46fa-9b7d-c60dcd94a133")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30125)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 93.15 82.37145) (xy 92.85 82.37145) (xy 92.433329 82.550559) (xy 92.6 82.801) (xy 92.849441 82.966671)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 93.139258 82.374877) (xy 93.142685 82.38315) (xy 93.141429 82.388424) (xy 92.85538 82.954908)
-				(xy 92.848592 82.960748) (xy 92.839662 82.960078) (xy 92.838463 82.95938) (xy 92.601962 82.802303)
-				(xy 92.598695 82.799039) (xy 92.587034 82.781518) (xy 92.441105 82.562244) (xy 92.439375 82.55346)
-				(xy 92.444364 82.546024) (xy 92.446219 82.545017) (xy 92.760583 82.409886) (xy 92.847788 82.372401)
-				(xy 92.852409 82.37145) (xy 93.130985 82.37145)
-			)
-		)
-	)
-	(zone
-		(net 109)
-		(net_name "/MCU/SPI1_MISO")
-		(layer "F.Cu")
-		(uuid "34db434b-20f7-4400-9829-9830425c80b2")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30022)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 80.35 117.894236) (xy 80.65 117.894236) (xy 80.794236 117.358527) (xy 80.5 117.299) (xy 80.205764 117.358527)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 80.782017 117.356055) (xy 80.789445 117.361054) (xy 80.791164 117.369842) (xy 80.790994 117.370564)
-				(xy 80.652331 117.885578) (xy 80.646871 117.892676) (xy 80.641033 117.894236) (xy 80.358967 117.894236)
-				(xy 80.350694 117.890809) (xy 80.347669 117.885578) (xy 80.209005 117.370564) (xy 80.210163 117.361684)
-				(xy 80.217261 117.356224) (xy 80.217953 117.35606) (xy 80.497682 117.299469) (xy 80.502318 117.299469)
+				(xy 87.093816 122.456055) (xy 87.101244 122.461054) (xy 87.102963 122.469842) (xy 87.102793 122.470564)
+				(xy 86.96413 122.985578) (xy 86.95867 122.992676) (xy 86.952832 122.994236) (xy 86.670766 122.994236)
+				(xy 86.662493 122.990809) (xy 86.659468 122.985578) (xy 86.520804 122.470564) (xy 86.521962 122.461684)
+				(xy 86.52906 122.456224) (xy 86.529752 122.45606) (xy 86.809481 122.399469) (xy 86.814117 122.399469)
 			)
 		)
 	)
@@ -43526,10 +43750,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "3b2b1dd5-c676-4453-b212-1e67ecdb700c")
+		(uuid "3cff4b30-5a1a-4091-a3da-4d373666e43b")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30130)
+		(priority 30126)
 		(attr
 			(teardrop
 				(type padvia)
@@ -43548,13 +43772,15 @@
 		)
 		(polygon
 			(pts
-				(xy 84.87762 109.835103) (xy 84.87762 110.135103) (xy 85.005764 110.458527) (xy 85.301 110.4) (xy 85.466671 110.150559)
+				(xy 94.087345 84.074786) (xy 93.875214 83.862655) (xy 93.458527 83.705765) (xy 93.399293 84.000708)
+				(xy 93.458527 84.294237)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 85.466671 110.150559) (xy 85.301 110.4) (xy 85.005764 110.458527) (xy 84.87762 110.135103) (xy 84.87762 109.835103)
+				(xy 93.875214 83.862655) (xy 94.087345 84.074786) (xy 93.458527 84.294237) (xy 93.399293 84.000708)
+				(xy 93.458527 83.705765)
 			)
 		)
 	)
@@ -43562,10 +43788,10 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "3df28038-12a8-4b7c-9f13-e9a98b8b6cea")
+		(uuid "3fc66a9b-fbb8-4290-94da-78ebeb631981")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30129)
+		(priority 30038)
 		(attr
 			(teardrop
 				(type padvia)
@@ -43584,17 +43810,17 @@
 		)
 		(polygon
 			(pts
-				(xy 59.816369 130.989772) (xy 59.516369 130.989772) (xy 59.133329 131.150559) (xy 59.3 131.401)
-				(xy 59.549441 131.566671)
+				(xy 86.961799 120.005764) (xy 86.661799 120.005764) (xy 86.505764 120.541473) (xy 86.8 120.601)
+				(xy 87.094236 120.541473)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 59.806337 130.993199) (xy 59.809764 131.001472) (xy 59.808682 131.006385) (xy 59.555169 131.554291)
-				(xy 59.548585 131.56036) (xy 59.539638 131.559996) (xy 59.538078 131.559124) (xy 59.301962 131.402303)
-				(xy 59.298695 131.399039) (xy 59.141174 131.162347) (xy 59.139443 131.153561) (xy 59.144432 131.146125)
-				(xy 59.146376 131.145082) (xy 59.514196 130.990683) (xy 59.518724 130.989772) (xy 59.798064 130.989772)
+				(xy 86.960912 120.009191) (xy 86.963997 120.014656) (xy 87.091305 120.529618) (xy 87.089964 120.538472)
+				(xy 87.082755 120.543784) (xy 87.082267 120.543894) (xy 86.80232 120.60053) (xy 86.79768 120.60053)
+				(xy 86.518235 120.543996) (xy 86.510806 120.538996) (xy 86.509087 120.530208) (xy 86.509322 120.529256)
+				(xy 86.659344 120.014192) (xy 86.664947 120.007207) (xy 86.670577 120.005764) (xy 86.952639 120.005764)
 			)
 		)
 	)
@@ -43602,7 +43828,7 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "403e278a-72f7-4a77-a2f8-632915163cf2")
+		(uuid "3fdbb759-af80-4f66-9e50-71c538bbc901")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30116)
@@ -43633,6 +43859,316 @@
 			(pts
 				(xy 85.204289 117.65) (xy 84.841453 117.936046) (xy 84.673782 117.686605) (xy 84.616255 117.392369)
 				(xy 85.204289 117.35)
+			)
+		)
+	)
+	(zone
+		(net 84)
+		(net_name "/MCU/SPI1_MOSI")
+		(layer "F.Cu")
+		(uuid "41abac93-c9f2-4a60-b19c-ee9aec2a5d45")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30101)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 81.114122 116.826254) (xy 81.326254 116.614122) (xy 81.049441 116.133329) (xy 80.799293 116.299293)
+				(xy 80.633329 116.549441)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 81.055269 116.143502) (xy 81.05566 116.144132) (xy 81.32178 116.606351) (xy 81.322938 116.615231)
+				(xy 81.319913 116.620462) (xy 81.120462 116.819913) (xy 81.112189 116.82334) (xy 81.106351 116.82178)
+				(xy 80.644132 116.55566) (xy 80.638672 116.548562) (xy 80.63983 116.539682) (xy 80.64021 116.539068)
+				(xy 80.797985 116.301263) (xy 80.801263 116.297985) (xy 81.039053 116.14022) (xy 81.04784 116.138502)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "42bdc479-f507-4231-8d12-0a132ab75732")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30083)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 69.610491 134.250868) (xy 69.822623 134.463) (xy 70.266671 134.149441) (xy 70.100707 133.899293)
+				(xy 69.850559 133.733329)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 69.860364 133.739994) (xy 69.861906 133.740857) (xy 70.089166 133.891636) (xy 70.098734 133.897984)
+				(xy 70.102015 133.901265) (xy 70.260388 134.139971) (xy 70.262107 134.148759) (xy 70.257388 134.155996)
+				(xy 69.830675 134.457314) (xy 69.82194 134.459287) (xy 69.815653 134.45603) (xy 69.616271 134.256648)
+				(xy 69.612844 134.248375) (xy 69.613929 134.243456) (xy 69.844827 133.745684) (xy 69.851417 133.739622)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "44252f98-8cbb-4a2e-9869-7ccaabb5cb76")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30053)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 85.194236 121.6618) (xy 85.194236 121.3618) (xy 84.658527 121.205764) (xy 84.599 121.5) (xy 84.658527 121.794236)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 85.194236 121.3618) (xy 85.194236 121.6618) (xy 84.658527 121.794236) (xy 84.599 121.5) (xy 84.658527 121.205764)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "4522e514-3f2f-4af2-b827-19790fb5c45c")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30096)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 56.985878 69.773746) (xy 56.773746 69.985878) (xy 57.050559 70.466671) (xy 57.300707 70.300707)
+				(xy 57.466671 70.050559)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 56.993646 69.778218) (xy 57.278798 69.942392) (xy 57.455867 70.044339) (xy 57.461327 70.051437)
+				(xy 57.460169 70.060317) (xy 57.459778 70.060947) (xy 57.302015 70.298734) (xy 57.298734 70.302015)
+				(xy 57.060947 70.459778) (xy 57.052159 70.461497) (xy 57.04473 70.456497) (xy 57.044339 70.455867)
+				(xy 56.816966 70.060947) (xy 56.778218 69.993646) (xy 56.777061 69.984768) (xy 56.780084 69.979539)
+				(xy 56.979538 69.780085) (xy 56.98781 69.776659)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "452e3170-889b-4462-8371-5e3b5963b11e")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30132)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 91.9 85.809318) (xy 91.6 85.809318) (xy 91.333329 86.050559) (xy 91.5 86.301) (xy 91.794236 86.358527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 91.794236 86.358527) (xy 91.5 86.301) (xy 91.333329 86.050559) (xy 91.6 85.809318) (xy 91.9 85.809318)
+			)
+		)
+	)
+	(zone
+		(net 56)
+		(net_name "/Flash/~{CS}")
+		(layer "F.Cu")
+		(uuid "4551c8f6-00a0-464c-a963-11b227187b2c")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30085)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 72.273746 122.014122) (xy 72.485879 122.226254) (xy 72.966671 121.949441) (xy 72.800707 121.699293)
+				(xy 72.550559 121.533329)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 72.560317 121.53983) (xy 72.560947 121.540221) (xy 72.798734 121.697984) (xy 72.802015 121.701265)
+				(xy 72.959778 121.939052) (xy 72.961497 121.94784) (xy 72.956497 121.955269) (xy 72.955867 121.95566)
+				(xy 72.493649 122.22178) (xy 72.484769 122.222938) (xy 72.479538 122.219913) (xy 72.280086 122.020462)
+				(xy 72.276659 122.012189) (xy 72.278218 122.006354) (xy 72.544339 121.544131) (xy 72.551437 121.538672)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "45598ad9-65f9-435b-a594-96996015dd71")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30113)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 85.177235 117.35) (xy 85.177235 117.65) (xy 85.710016 117.859832) (xy 85.769543 117.565596)
+				(xy 85.710016 117.27136)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 85.769543 117.565596) (xy 85.710016 117.859832) (xy 85.177235 117.65) (xy 85.177235 117.35)
+				(xy 85.710016 117.27136)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "47cbec60-2912-44c8-83e5-cc590e688f69")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30011)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 95.405764 137.75) (xy 95.405764 138.25) (xy 95.941473 138.294236) (xy 96.001 138) (xy 95.941473 137.705764)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 95.939631 137.709354) (xy 95.943535 137.71596) (xy 96.00053 137.99768) (xy 96.00053 138.00232)
+				(xy 95.943535 138.284039) (xy 95.938535 138.291468) (xy 95.931104 138.293379) (xy 95.416501 138.250886)
+				(xy 95.408538 138.24679) (xy 95.405764 138.239226) (xy 95.405764 137.760773) (xy 95.409191 137.7525)
+				(xy 95.416499 137.749113) (xy 95.931104 137.70662)
 			)
 		)
 	)
@@ -45940,13 +46476,13 @@
 		)
 	)
 	(zone
-		(net 108)
-		(net_name "/MCU/MAG_INT")
+		(net 87)
+		(net_name "/MCU/BATT_ISENSE")
 		(layer "F.Cu")
-		(uuid "498c5ad4-0455-4662-8237-57fbe2824450")
+		(uuid "4b7acf57-1d60-45ce-bcf2-57364ae86987")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30081)
+		(priority 30029)
 		(attr
 			(teardrop
 				(type padvia)
@@ -45965,56 +46501,16 @@
 		)
 		(polygon
 			(pts
-				(xy 79.121229 109.419148) (xy 79.333361 109.207016) (xy 79.049441 108.733329) (xy 78.799293 108.899293)
-				(xy 78.633329 109.149441)
+				(xy 91.65 74.605764) (xy 91.35 74.605764) (xy 91.205764 75.141473) (xy 91.5 75.201) (xy 91.794236 75.141473)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 79.055451 108.743381) (xy 79.055737 108.743834) (xy 79.328666 109.199184) (xy 79.32998 109.208042)
-				(xy 79.326904 109.213472) (xy 79.127455 109.412921) (xy 79.119182 109.416348) (xy 79.113523 109.414888)
-				(xy 78.644431 109.155578) (xy 78.638848 109.148576) (xy 78.639851 109.139678) (xy 78.640342 109.13887)
-				(xy 78.797985 108.901263) (xy 78.801263 108.897985) (xy 79.039236 108.740099) (xy 79.048022 108.738381)
-			)
-		)
-	)
-	(zone
-		(net 81)
-		(net_name "/MCU/SPI4_NSS")
-		(layer "F.Cu")
-		(uuid "4a8427d2-8021-4ec1-b31f-2a0e9b09a968")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30047)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 84.005764 114.35) (xy 84.005764 114.65) (xy 84.541473 114.794236) (xy 84.601 114.5) (xy 84.541473 114.205764)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 84.538315 114.210163) (xy 84.543775 114.217261) (xy 84.543945 114.217983) (xy 84.60053 114.49768)
-				(xy 84.60053 114.50232) (xy 84.543945 114.782016) (xy 84.538945 114.789445) (xy 84.530157 114.791164)
-				(xy 84.529435 114.790994) (xy 84.014422 114.652331) (xy 84.007324 114.646871) (xy 84.005764 114.641033)
-				(xy 84.005764 114.358966) (xy 84.009191 114.350693) (xy 84.014419 114.347669) (xy 84.529435 114.209005)
+				(xy 91.649306 74.609191) (xy 91.652331 74.614422) (xy 91.790994 75.129435) (xy 91.789836 75.138315)
+				(xy 91.782738 75.143775) (xy 91.782016 75.143945) (xy 91.50232 75.20053) (xy 91.49768 75.20053)
+				(xy 91.217983 75.143945) (xy 91.210554 75.138945) (xy 91.208835 75.130157) (xy 91.209005 75.129435)
+				(xy 91.347669 74.614422) (xy 91.353129 74.607324) (xy 91.358967 74.605764) (xy 91.641033 74.605764)
 			)
 		)
 	)
@@ -46022,10 +46518,10 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "4b0886c2-806e-4366-b313-3fbd842c3edc")
+		(uuid "4b7e876d-b458-41dc-aa1b-eb5ed8649aa7")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30082)
+		(priority 30090)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46044,28 +46540,28 @@
 		)
 		(polygon
 			(pts
-				(xy 70.834401 136.005976) (xy 71.046533 135.793844) (xy 70.749441 135.333329) (xy 70.499293 135.499293)
-				(xy 70.333329 135.749441)
+				(xy 70.626254 133.585878) (xy 70.414122 133.373746) (xy 69.933329 133.650559) (xy 70.099293 133.900707)
+				(xy 70.349441 134.066671)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 70.755782 135.343162) (xy 70.755865 135.343287) (xy 71.041412 135.785907) (xy 71.043017 135.794717)
-				(xy 71.039853 135.800523) (xy 70.840423 135.999953) (xy 70.83215 136.00338) (xy 70.826819 136.002094)
-				(xy 70.344986 135.755409) (xy 70.339184 135.748589) (xy 70.339904 135.739663) (xy 70.340561 135.73854)
-				(xy 70.497985 135.501263) (xy 70.501263 135.497985) (xy 70.739565 135.33988) (xy 70.748353 135.338162)
+				(xy 70.420462 133.380086) (xy 70.619913 133.579537) (xy 70.62334 133.58781) (xy 70.62178 133.593648)
+				(xy 70.35566 134.055867) (xy 70.348562 134.061327) (xy 70.339682 134.060169) (xy 70.339052 134.059778)
+				(xy 70.101265 133.902015) (xy 70.097984 133.898734) (xy 69.940221 133.660947) (xy 69.938502 133.652159)
+				(xy 69.943502 133.64473) (xy 69.944132 133.644339) (xy 70.406353 133.378218) (xy 70.415231 133.377061)
 			)
 		)
 	)
 	(zone
-		(net 3)
-		(net_name "GND")
+		(net 84)
+		(net_name "/MCU/SPI1_MOSI")
 		(layer "F.Cu")
-		(uuid "4cbdc328-6f24-4b7e-8f3a-a26c69aec5ec")
+		(uuid "4da318fe-af69-4c3d-b3c2-f8f47a052535")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30094)
+		(priority 30135)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46084,26 +46580,28 @@
 		)
 		(polygon
 			(pts
-				(xy 67.785878 72.173746) (xy 67.573746 72.385878) (xy 67.850559 72.866671) (xy 68.100707 72.700707)
-				(xy 68.266671 72.450559)
+				(xy 77.268795 113.50641) (xy 77.056663 113.718542) (xy 77.533329 113.999442) (xy 77.700707 113.750708)
+				(xy 77.641473 113.455765)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 68.266671 72.450559) (xy 68.100707 72.700707) (xy 67.850559 72.866671) (xy 67.573746 72.385878)
-				(xy 67.785878 72.173746)
+				(xy 77.639248 113.459525) (xy 77.643635 113.466533) (xy 77.699745 113.745921) (xy 77.698014 113.754707)
+				(xy 77.697981 113.754757) (xy 77.539481 113.990298) (xy 77.532019 113.995249) (xy 77.523834 113.993846)
+				(xy 77.069678 113.726212) (xy 77.06429 113.719059) (xy 77.065538 113.710192) (xy 77.067341 113.707863)
+				(xy 77.266007 113.509197) (xy 77.272701 113.505879) (xy 77.630589 113.457244)
 			)
 		)
 	)
 	(zone
-		(net 3)
-		(net_name "GND")
+		(net 59)
+		(net_name "/MCU/BUZZER")
 		(layer "F.Cu")
-		(uuid "51bad08c-11c2-4fab-863a-afaf79b84423")
+		(uuid "4f35cd4a-5c46-40a9-bfa2-596a9c56ba72")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30053)
+		(priority 30060)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46122,24 +46620,27 @@
 		)
 		(polygon
 			(pts
-				(xy 85.194236 121.6618) (xy 85.194236 121.3618) (xy 84.658527 121.205764) (xy 84.599 121.5) (xy 84.658527 121.794236)
+				(xy 73.85 129.694236) (xy 74.15 129.694236) (xy 74.294236 129.158527) (xy 74 129.099) (xy 73.705764 129.158527)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 85.194236 121.3618) (xy 85.194236 121.6618) (xy 84.658527 121.794236) (xy 84.599 121.5) (xy 84.658527 121.205764)
+				(xy 74.282017 129.156055) (xy 74.289445 129.161054) (xy 74.291164 129.169842) (xy 74.290994 129.170564)
+				(xy 74.152331 129.685578) (xy 74.146871 129.692676) (xy 74.141033 129.694236) (xy 73.858967 129.694236)
+				(xy 73.850694 129.690809) (xy 73.847669 129.685578) (xy 73.709005 129.170564) (xy 73.710163 129.161684)
+				(xy 73.717261 129.156224) (xy 73.717953 129.15606) (xy 73.997682 129.099469) (xy 74.002318 129.099469)
 			)
 		)
 	)
 	(zone
-		(net 3)
-		(net_name "GND")
+		(net 82)
+		(net_name "/MCU/SPI4_SCK")
 		(layer "F.Cu")
-		(uuid "5301df7e-7550-4598-8298-d2efcc783279")
+		(uuid "50f57b56-9605-4fec-b70d-53f5f0757c69")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30049)
+		(priority 30100)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46158,13 +46659,18 @@
 		)
 		(polygon
 			(pts
-				(xy 76.95 67.705764) (xy 76.65 67.705764) (xy 76.505764 68.241473) (xy 76.8 68.301) (xy 77.094236 68.241473)
+				(xy 82.785878 113.573746) (xy 82.573746 113.785878) (xy 82.850559 114.266671) (xy 83.100707 114.100707)
+				(xy 83.266671 113.850559)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 77.094236 68.241473) (xy 76.8 68.301) (xy 76.505764 68.241473) (xy 76.65 67.705764) (xy 76.95 67.705764)
+				(xy 82.793646 113.578218) (xy 83.078798 113.742392) (xy 83.255867 113.844339) (xy 83.261327 113.851437)
+				(xy 83.260169 113.860317) (xy 83.259778 113.860947) (xy 83.102015 114.098734) (xy 83.098734 114.102015)
+				(xy 82.860947 114.259778) (xy 82.852159 114.261497) (xy 82.84473 114.256497) (xy 82.844339 114.255867)
+				(xy 82.616966 113.860947) (xy 82.578218 113.793646) (xy 82.577061 113.784768) (xy 82.580084 113.779539)
+				(xy 82.779538 113.580085) (xy 82.78781 113.576659)
 			)
 		)
 	)
@@ -46218,13 +46724,13 @@
 		)
 	)
 	(zone
-		(net 1)
-		(net_name "+3V3")
+		(net 3)
+		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "54437af3-56b1-40e4-bd6b-1cb4fc6ef0cd")
+		(uuid "53740dc5-80c5-4afd-aba7-a8949fcf3af7")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30122)
+		(priority 30145)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46243,16 +46749,94 @@
 		)
 		(polygon
 			(pts
-				(xy 54.585636 84.670712) (xy 54.585636 84.370712) (xy 54.058527 84.305764) (xy 53.999 84.6) (xy 54.166671 84.849441)
+				(xy 86.45 53.1) (xy 86.75 53.1) (xy 86.849441 52.866671) (xy 86.6 52.699) (xy 86.350559 52.866671)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 54.575368 84.369446) (xy 54.583159 84.373859) (xy 54.585636 84.381058) (xy 54.585636 84.662982)
-				(xy 54.582209 84.671255) (xy 54.578527 84.673744) (xy 54.175572 84.845643) (xy 54.166618 84.845737)
-				(xy 54.161271 84.841408) (xy 54.001727 84.604057) (xy 53.999956 84.595279) (xy 53.999969 84.59521)
-				(xy 54.043294 84.381058) (xy 54.056379 84.316379) (xy 54.061379 84.308951) (xy 54.069276 84.307088)
+				(xy 86.849441 52.866671) (xy 86.75 53.1) (xy 86.45 53.1) (xy 86.350559 52.866671) (xy 86.6 52.699)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "55966959-4223-4c30-9e5d-a06f1fb1b2b8")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30129)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 59.816369 130.989772) (xy 59.516369 130.989772) (xy 59.133329 131.150559) (xy 59.3 131.401)
+				(xy 59.549441 131.566671)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 59.806337 130.993199) (xy 59.809764 131.001472) (xy 59.808682 131.006385) (xy 59.555169 131.554291)
+				(xy 59.548585 131.56036) (xy 59.539638 131.559996) (xy 59.538078 131.559124) (xy 59.301962 131.402303)
+				(xy 59.298695 131.399039) (xy 59.141174 131.162347) (xy 59.139443 131.153561) (xy 59.144432 131.146125)
+				(xy 59.146376 131.145082) (xy 59.514196 130.990683) (xy 59.518724 130.989772) (xy 59.798064 130.989772)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "567d9ac2-1257-46ff-9c1d-4d3d5748e9ae")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30110)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 83.828519 106.631106) (xy 83.616387 106.843238) (xy 83.893199 107.324031) (xy 84.143347 107.158067)
+				(xy 84.309311 106.907919)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 83.836287 106.635578) (xy 84.119078 106.798393) (xy 84.298507 106.901699) (xy 84.303967 106.908797)
+				(xy 84.302809 106.917677) (xy 84.302418 106.918307) (xy 84.144655 107.156094) (xy 84.141374 107.159375)
+				(xy 83.903587 107.317138) (xy 83.894799 107.318857) (xy 83.88737 107.313857) (xy 83.886979 107.313227)
+				(xy 83.659607 106.918307) (xy 83.620859 106.851006) (xy 83.619702 106.842128) (xy 83.622725 106.836899)
+				(xy 83.822179 106.637445) (xy 83.830451 106.634019)
 			)
 		)
 	)
@@ -46260,10 +46844,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "54cf5f1a-e96f-4f9e-bf35-7624db47d2d6")
+		(uuid "57437e8d-da1a-4348-b326-0b8d9b87bb33")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30078)
+		(priority 30049)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46282,13 +46866,13 @@
 		)
 		(polygon
 			(pts
-				(xy 85.194236 119.8618) (xy 85.194236 119.5618) (xy 84.658527 119.405764) (xy 84.599 119.7) (xy 84.658527 119.994236)
+				(xy 76.95 67.705764) (xy 76.65 67.705764) (xy 76.505764 68.241473) (xy 76.8 68.301) (xy 77.094236 68.241473)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 85.194236 119.5618) (xy 85.194236 119.8618) (xy 84.658527 119.994236) (xy 84.599 119.7) (xy 84.658527 119.405764)
+				(xy 77.094236 68.241473) (xy 76.8 68.301) (xy 76.505764 68.241473) (xy 76.65 67.705764) (xy 76.95 67.705764)
 			)
 		)
 	)
@@ -46296,7 +46880,388 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "596eeec5-737b-41de-85c6-c382b6d8d6db")
+		(uuid "58d89db6-fb0b-4706-8945-77ad7f943ac9")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30006)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 107.294236 142.25) (xy 107.294236 141.75) (xy 106.758527 141.705764) (xy 106.699 142) (xy 106.758527 142.294236)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 107.283499 141.749113) (xy 107.291462 141.753209) (xy 107.294236 141.760773) (xy 107.294236 142.239226)
+				(xy 107.290809 142.247499) (xy 107.283499 142.250886) (xy 106.768895 142.293379) (xy 106.760368 142.290645)
+				(xy 106.756464 142.284039) (xy 106.699469 142.00232) (xy 106.699469 141.99768) (xy 106.749578 141.75)
+				(xy 106.756464 141.715959) (xy 106.761464 141.708531) (xy 106.768894 141.70662)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "58daf474-9ee5-487f-8740-89021822d624")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30144)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 82.999999 134.0875) (xy 82.999999 134.3875) (xy 83.458527 134.294236) (xy 83.401 134) (xy 83.150559 133.833329)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 83.401 134) (xy 83.458527 134.294236) (xy 82.999999 134.3875) (xy 82.999999 134.0875) (xy 83.150559 133.833329)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "5a14eaa5-70c1-4614-9c16-012d048495cc")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30031)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 57.794236 76.405977) (xy 57.794236 76.105977) (xy 57.258527 76.005764) (xy 57.199 76.3) (xy 57.258527 76.594236)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 57.784688 76.10419) (xy 57.792189 76.10908) (xy 57.794236 76.115691) (xy 57.794236 76.397687)
+				(xy 57.790809 76.40596) (xy 57.786415 76.408725) (xy 57.271208 76.589779) (xy 57.262267 76.589289)
+				(xy 57.256291 76.58262) (xy 57.255863 76.581068) (xy 57.199469 76.302318) (xy 57.199469 76.29768)
+				(xy 57.256241 76.017062) (xy 57.26124 76.009635) (xy 57.269856 76.007883)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "5a7ac36e-e98e-4ca5-8841-d6423de3ae83")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30092)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 49.214122 109.826254) (xy 49.426254 109.614122) (xy 49.149441 109.133329) (xy 48.899293 109.299293)
+				(xy 48.733329 109.549441)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 49.426254 109.614122) (xy 49.214122 109.826254) (xy 48.733329 109.549441) (xy 48.899293 109.299293)
+				(xy 49.149441 109.133329)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "5af645a2-a652-47ea-9fce-e86058db70b6")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30027)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 86.661799 119.394236) (xy 86.961799 119.394236) (xy 87.094236 118.858527) (xy 86.8 118.799)
+				(xy 86.505764 118.858527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 87.082268 118.856105) (xy 87.089696 118.861105) (xy 87.091415 118.869893) (xy 87.091305 118.870381)
+				(xy 86.963997 119.385344) (xy 86.958685 119.392553) (xy 86.952639 119.394236) (xy 86.670577 119.394236)
+				(xy 86.662304 119.390809) (xy 86.659344 119.385808) (xy 86.509322 118.870743) (xy 86.510298 118.861841)
+				(xy 86.517283 118.856238) (xy 86.518212 118.856008) (xy 86.797682 118.799469) (xy 86.802318 118.799469)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "5c5c4cdc-8367-402d-881b-0fd12e5d3aed")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30048)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 75.05 67.705764) (xy 74.75 67.705764) (xy 74.605764 68.241473) (xy 74.9 68.301) (xy 75.194236 68.241473)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 75.194236 68.241473) (xy 74.9 68.301) (xy 74.605764 68.241473) (xy 74.75 67.705764) (xy 75.05 67.705764)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "602c16cb-a2d4-4821-a8b3-b733467bd2c6")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30107)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 48.45 100.305765) (xy 48.150001 100.305764) (xy 48.005764 100.841473) (xy 48.3 100.900999) (xy 48.594236 100.841473)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 48.449306 100.309191) (xy 48.452331 100.314422) (xy 48.590994 100.829435) (xy 48.589836 100.838315)
+				(xy 48.582738 100.843775) (xy 48.582016 100.843945) (xy 48.30232 100.900529) (xy 48.29768 100.900529)
+				(xy 48.017983 100.843945) (xy 48.010554 100.838945) (xy 48.008835 100.830157) (xy 48.009005 100.829435)
+				(xy 48.14767 100.31442) (xy 48.153129 100.307324) (xy 48.158966 100.305764) (xy 48.441035 100.305764)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "627a4587-a8db-47e1-9049-b8020c5ba7a3")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30071)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 91.9 71.194236) (xy 92.2 71.194236) (xy 92.294236 70.658527) (xy 92 70.599) (xy 91.705764 70.658527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 92.294236 70.658527) (xy 92.2 71.194236) (xy 91.9 71.194236) (xy 91.705764 70.658527) (xy 92 70.599)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "62a4c7a9-fc64-4f7f-9c7b-5e84f93e0c8c")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30014)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 84.243411 57.696964) (xy 84.596964 57.343411) (xy 84.249441 56.933329) (xy 83.999293 57.099293)
+				(xy 83.833329 57.349441)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 84.596964 57.343411) (xy 84.243411 57.696964) (xy 83.833329 57.349441) (xy 83.999293 57.099293)
+				(xy 84.249441 56.933329)
+			)
+		)
+	)
+	(zone
+		(net 82)
+		(net_name "/MCU/SPI4_SCK")
+		(layer "F.Cu")
+		(uuid "62b97bfd-71f1-4dac-afaa-7333e4c3087b")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30044)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 86.600001 116.294236) (xy 86.900001 116.294236) (xy 86.994236 115.758527) (xy 86.7 115.699)
+				(xy 86.405764 115.758527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 86.983056 115.756265) (xy 86.990485 115.761265) (xy 86.992259 115.76976) (xy 86.901703 116.284563)
+				(xy 86.896895 116.292117) (xy 86.89018 116.294236) (xy 86.608204 116.294236) (xy 86.599931 116.290809)
+				(xy 86.597205 116.286524) (xy 86.548475 116.152128) (xy 86.410391 115.771288) (xy 86.410792 115.762344)
+				(xy 86.417402 115.756303) (xy 86.419056 115.755837) (xy 86.697682 115.699469) (xy 86.702318 115.699469)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "62ff850c-3210-4c3f-9af9-f8a58a1ce0e9")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30079)
@@ -46333,13 +47298,13 @@
 		)
 	)
 	(zone
-		(net 75)
-		(net_name "/MCU/IMU_INT2")
+		(net 116)
+		(net_name "/MCU/SPI1_SCK")
 		(layer "F.Cu")
-		(uuid "59eaab0b-4625-47db-bc3a-483fc8f2f7c4")
+		(uuid "66281b49-1f0f-4df0-9b8b-45730c113a3e")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30057)
+		(priority 30086)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46358,16 +47323,17 @@
 		)
 		(polygon
 			(pts
-				(xy 91.6 82.844237) (xy 91.9 82.844237) (xy 92.044236 82.308528) (xy 91.75 82.249001) (xy 91.455764 82.308528)
+				(xy 82.814122 126.026254) (xy 83.026254 125.814122) (xy 82.749441 125.333329) (xy 82.499293 125.499293)
+				(xy 82.333329 125.749441)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 92.032017 82.306056) (xy 92.039445 82.311055) (xy 92.041164 82.319843) (xy 92.040994 82.320565)
-				(xy 91.902331 82.835579) (xy 91.896871 82.842677) (xy 91.891033 82.844237) (xy 91.608967 82.844237)
-				(xy 91.600694 82.84081) (xy 91.597669 82.835579) (xy 91.459005 82.320565) (xy 91.460163 82.311685)
-				(xy 91.467261 82.306225) (xy 91.467953 82.306061) (xy 91.747682 82.24947) (xy 91.752318 82.24947)
+				(xy 82.755269 125.343502) (xy 82.75566 125.344132) (xy 83.02178 125.806351) (xy 83.022938 125.815231)
+				(xy 83.019913 125.820462) (xy 82.820462 126.019913) (xy 82.812189 126.02334) (xy 82.806351 126.02178)
+				(xy 82.344132 125.75566) (xy 82.338672 125.748562) (xy 82.33983 125.739682) (xy 82.34021 125.739068)
+				(xy 82.497985 125.501263) (xy 82.501263 125.497985) (xy 82.739053 125.34022) (xy 82.74784 125.338502)
 			)
 		)
 	)
@@ -46375,10 +47341,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "5d24e81f-ddee-4b84-9d2a-a4a4e7b4004a")
+		(uuid "67b238dd-bc11-4ca3-aa61-c563e7614c2b")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30121)
+		(priority 30080)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46397,52 +47363,13 @@
 		)
 		(polygon
 			(pts
-				(xy 82.65 135.7625) (xy 82.35 135.7625) (xy 82.100556 136.133329) (xy 82.349997 136.301) (xy 82.644233 136.358527)
+				(xy 48.794236 97.15) (xy 48.794236 96.85) (xy 48.258527 96.705764) (xy 48.199 97) (xy 48.258527 97.294236)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 82.644233 136.358527) (xy 82.349997 136.301) (xy 82.100556 136.133329) (xy 82.35 135.7625) (xy 82.65 135.7625)
-			)
-		)
-	)
-	(zone
-		(net 57)
-		(net_name "/MCU/SERVO_EN")
-		(layer "F.Cu")
-		(uuid "5ef98f17-ba24-40c0-81e3-2de7909506b1")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30117)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 91.75 63.65) (xy 91.75 63.35) (xy 91.258527 63.205764) (xy 91.199 63.5) (xy 91.258527 63.794236)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 91.270752 63.209351) (xy 91.741595 63.347533) (xy 91.748568 63.353151) (xy 91.75 63.35876) (xy 91.75 63.641239)
-				(xy 91.746573 63.649512) (xy 91.741595 63.652466) (xy 91.270761 63.790645) (xy 91.261857 63.789686)
-				(xy 91.256239 63.782713) (xy 91.256 63.781749) (xy 91.199469 63.502318) (xy 91.199469 63.49768)
-				(xy 91.228709 63.353151) (xy 91.255999 63.218259) (xy 91.260998 63.210832) (xy 91.269786 63.209113)
+				(xy 48.794236 96.85) (xy 48.794236 97.15) (xy 48.258527 97.294236) (xy 48.199 97) (xy 48.258527 96.705764)
 			)
 		)
 	)
@@ -46450,10 +47377,10 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "601b047d-0fcf-495c-8e9b-240d9425dcf5")
+		(uuid "683948e0-dd5e-4fcf-8cf0-4c23cbff005a")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30096)
+		(priority 30010)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46472,18 +47399,16 @@
 		)
 		(polygon
 			(pts
-				(xy 56.985878 69.773746) (xy 56.773746 69.985878) (xy 57.050559 70.466671) (xy 57.300707 70.300707)
-				(xy 57.466671 70.050559)
+				(xy 107.75 141.794236) (xy 108.25 141.794236) (xy 108.294236 141.258527) (xy 108 141.199) (xy 107.705764 141.258527)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 56.993646 69.778218) (xy 57.278798 69.942392) (xy 57.455867 70.044339) (xy 57.461327 70.051437)
-				(xy 57.460169 70.060317) (xy 57.459778 70.060947) (xy 57.302015 70.298734) (xy 57.298734 70.302015)
-				(xy 57.060947 70.459778) (xy 57.052159 70.461497) (xy 57.04473 70.456497) (xy 57.044339 70.455867)
-				(xy 56.816966 70.060947) (xy 56.778218 69.993646) (xy 56.777061 69.984768) (xy 56.780084 69.979539)
-				(xy 56.979538 69.780085) (xy 56.98781 69.776659)
+				(xy 108.284039 141.256464) (xy 108.291468 141.261464) (xy 108.293379 141.268895) (xy 108.250887 141.783499)
+				(xy 108.246791 141.791462) (xy 108.239227 141.794236) (xy 107.760773 141.794236) (xy 107.7525 141.790809)
+				(xy 107.749113 141.783499) (xy 107.70662 141.268895) (xy 107.709354 141.260368) (xy 107.715959 141.256464)
+				(xy 107.997682 141.199469) (xy 108.002318 141.199469)
 			)
 		)
 	)
@@ -46491,10 +47416,10 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "6136b9d6-030a-4842-9753-9d9df0d75506")
+		(uuid "68d3b57b-e12d-4e60-a534-75590bd32b27")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30016)
+		(priority 30125)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46513,17 +47438,17 @@
 		)
 		(polygon
 			(pts
-				(xy 84.386051 107.754324) (xy 84.739604 107.40077) (xy 84.392081 106.990689) (xy 84.141933 107.156653)
-				(xy 83.975969 107.406801)
+				(xy 93.15 82.37145) (xy 92.85 82.37145) (xy 92.433329 82.550559) (xy 92.6 82.801) (xy 92.849441 82.966671)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 84.398806 106.998625) (xy 84.732638 107.392551) (xy 84.735372 107.401078) (xy 84.731985 107.408388)
-				(xy 84.393669 107.746705) (xy 84.385396 107.750132) (xy 84.377832 107.747358) (xy 83.983905 107.413526)
-				(xy 83.979809 107.405563) (xy 83.981719 107.398133) (xy 84.140625 107.158623) (xy 84.143903 107.155345)
-				(xy 84.383413 106.996439) (xy 84.3922 106.994721)
+				(xy 93.139258 82.374877) (xy 93.142685 82.38315) (xy 93.141429 82.388424) (xy 92.85538 82.954908)
+				(xy 92.848592 82.960748) (xy 92.839662 82.960078) (xy 92.838463 82.95938) (xy 92.601962 82.802303)
+				(xy 92.598695 82.799039) (xy 92.587034 82.781518) (xy 92.441105 82.562244) (xy 92.439375 82.55346)
+				(xy 92.444364 82.546024) (xy 92.446219 82.545017) (xy 92.760583 82.409886) (xy 92.847788 82.372401)
+				(xy 92.852409 82.37145) (xy 93.130985 82.37145)
 			)
 		)
 	)
@@ -46531,10 +47456,10 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "6609687b-5ffa-4514-b09a-879aca7fef6c")
+		(uuid "6b81aa31-ce93-4134-b7ef-69186158665b")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30036)
+		(priority 30009)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46553,93 +47478,16 @@
 		)
 		(polygon
 			(pts
-				(xy 86.961799 121.805764) (xy 86.661799 121.805764) (xy 86.517563 122.341473) (xy 86.811799 122.401)
-				(xy 87.106035 122.341473)
+				(xy 107.294236 138.25) (xy 107.294236 137.75) (xy 106.758527 137.705764) (xy 106.699 138) (xy 106.758527 138.294236)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 86.961105 121.809191) (xy 86.96413 121.814422) (xy 87.102793 122.329435) (xy 87.101635 122.338315)
-				(xy 87.094537 122.343775) (xy 87.093815 122.343945) (xy 86.814119 122.40053) (xy 86.809479 122.40053)
-				(xy 86.529782 122.343945) (xy 86.522353 122.338945) (xy 86.520634 122.330157) (xy 86.520804 122.329435)
-				(xy 86.659468 121.814422) (xy 86.664928 121.807324) (xy 86.670766 121.805764) (xy 86.952832 121.805764)
-			)
-		)
-	)
-	(zone
-		(net 102)
-		(net_name "/MCU/SPI2_NSS")
-		(layer "F.Cu")
-		(uuid "66a89db4-a3be-4276-80f1-907737a95d1e")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30103)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 86.223746 101.564122) (xy 86.435878 101.776254) (xy 86.916671 101.499441) (xy 86.750707 101.249293)
-				(xy 86.500559 101.083329)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 86.510317 101.08983) (xy 86.510947 101.090221) (xy 86.748734 101.247984) (xy 86.752015 101.251265)
-				(xy 86.909778 101.489052) (xy 86.911497 101.49784) (xy 86.906497 101.505269) (xy 86.905867 101.50566)
-				(xy 86.443648 101.77178) (xy 86.434768 101.772938) (xy 86.429537 101.769913) (xy 86.230086 101.570462)
-				(xy 86.226659 101.562189) (xy 86.228218 101.556354) (xy 86.494339 101.094131) (xy 86.501437 101.088672)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "68884973-3cc4-4a1e-90d4-559a03c7f6fb")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30012)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 84.45 50.794236) (xy 84.95 50.794236) (xy 84.994236 50.258527) (xy 84.7 50.199) (xy 84.405764 50.258527)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 84.994236 50.258527) (xy 84.95 50.794236) (xy 84.45 50.794236) (xy 84.405764 50.258527) (xy 84.7 50.199)
+				(xy 107.283499 137.749113) (xy 107.291462 137.753209) (xy 107.294236 137.760773) (xy 107.294236 138.239226)
+				(xy 107.290809 138.247499) (xy 107.283499 138.250886) (xy 106.768895 138.293379) (xy 106.760368 138.290645)
+				(xy 106.756464 138.284039) (xy 106.699469 138.00232) (xy 106.699469 137.99768) (xy 106.749578 137.75)
+				(xy 106.756464 137.715959) (xy 106.761464 137.708531) (xy 106.768894 137.70662)
 			)
 		)
 	)
@@ -46686,13 +47534,13 @@
 		)
 	)
 	(zone
-		(net 31)
-		(net_name "/MCU/SERVO_SIG")
+		(net 1)
+		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "6f20dcec-26ee-457e-b172-2fb8c4342ce9")
+		(uuid "6e690af9-361f-4d50-8a55-c38861ec3752")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30037)
+		(priority 30002)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46711,16 +47559,16 @@
 		)
 		(polygon
 			(pts
-				(xy 72.405764 75.35) (xy 72.405764 75.65) (xy 72.941473 75.794236) (xy 73.001 75.5) (xy 72.941473 75.205764)
+				(xy 108.25 138.205764) (xy 107.75 138.205764) (xy 107.705764 138.741473) (xy 108 138.801) (xy 108.294236 138.741473)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 72.938315 75.210163) (xy 72.943775 75.217261) (xy 72.943945 75.217983) (xy 73.00053 75.49768)
-				(xy 73.00053 75.50232) (xy 72.943945 75.782016) (xy 72.938945 75.789445) (xy 72.930157 75.791164)
-				(xy 72.929435 75.790994) (xy 72.414422 75.652331) (xy 72.407324 75.646871) (xy 72.405764 75.641033)
-				(xy 72.405764 75.358966) (xy 72.409191 75.350693) (xy 72.414419 75.347669) (xy 72.929435 75.209005)
+				(xy 108.2475 138.209191) (xy 108.250887 138.216501) (xy 108.293379 138.731104) (xy 108.290645 138.739631)
+				(xy 108.284039 138.743535) (xy 108.00232 138.80053) (xy 107.99768 138.80053) (xy 107.71596 138.743535)
+				(xy 107.708531 138.738535) (xy 107.70662 138.731104) (xy 107.749113 138.216501) (xy 107.753209 138.208538)
+				(xy 107.760773 138.205764) (xy 108.239227 138.205764)
 			)
 		)
 	)
@@ -46728,10 +47576,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "6f647f1d-fa09-4c36-afe7-7ae4c8c06c9d")
+		(uuid "6f63fc8b-4410-435d-8641-67f14110f8c9")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30133)
+		(priority 30061)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46750,24 +47598,24 @@
 		)
 		(polygon
 			(pts
-				(xy 91.4 85.809318) (xy 91.1 85.809318) (xy 91.205764 86.358527) (xy 91.5 86.301) (xy 91.666671 86.050559)
+				(xy 92.2 71.805764) (xy 91.9 71.805764) (xy 91.805764 72.341473) (xy 92.1 72.401) (xy 92.394236 72.341473)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 91.666671 86.050559) (xy 91.5 86.301) (xy 91.205764 86.358527) (xy 91.1 85.809318) (xy 91.4 85.809318)
+				(xy 92.394236 72.341473) (xy 92.1 72.401) (xy 91.805764 72.341473) (xy 91.9 71.805764) (xy 92.2 71.805764)
 			)
 		)
 	)
 	(zone
-		(net 3)
-		(net_name "GND")
+		(net 49)
+		(net_name "/MCU/BOOT0")
 		(layer "F.Cu")
-		(uuid "709e4426-f32e-4af8-a103-547b1bc123be")
+		(uuid "6ff747dc-b128-4dae-9beb-02222ffd70a5")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30115)
+		(priority 30076)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46786,26 +47634,27 @@
 		)
 		(polygon
 			(pts
-				(xy 83.609848 107.119542) (xy 83.397717 107.331673) (xy 83.405764 107.821338) (xy 83.700707 107.763518)
-				(xy 83.949441 107.59614)
+				(xy 65.05 100.894236) (xy 65.35 100.894236) (xy 65.494236 100.358527) (xy 65.2 100.299) (xy 64.905764 100.358527)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 83.949441 107.59614) (xy 83.700707 107.763518) (xy 83.405764 107.821338) (xy 83.397717 107.331673)
-				(xy 83.609848 107.119542)
+				(xy 65.482017 100.356055) (xy 65.489445 100.361054) (xy 65.491164 100.369842) (xy 65.490994 100.370564)
+				(xy 65.352331 100.885578) (xy 65.346871 100.892676) (xy 65.341033 100.894236) (xy 65.058967 100.894236)
+				(xy 65.050694 100.890809) (xy 65.047669 100.885578) (xy 64.909005 100.370564) (xy 64.910163 100.361684)
+				(xy 64.917261 100.356224) (xy 64.917953 100.35606) (xy 65.197682 100.299469) (xy 65.202318 100.299469)
 			)
 		)
 	)
 	(zone
-		(net 3)
-		(net_name "GND")
+		(net 114)
+		(net_name "/MCU/IMU_INT1")
 		(layer "F.Cu")
-		(uuid "71bedd7a-2514-4ebd-ade1-8e7a217513df")
+		(uuid "79635874-0cb1-47f7-bf22-01a7e4876807")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30145)
+		(priority 30019)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46824,49 +47673,17 @@
 		)
 		(polygon
 			(pts
-				(xy 86.45 53.1) (xy 86.75 53.1) (xy 86.849441 52.866671) (xy 86.6 52.699) (xy 86.350559 52.866671)
+				(xy 93.394236 88.15) (xy 93.394236 87.85) (xy 92.858527 87.705764) (xy 92.799 88) (xy 92.858527 88.294236)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 86.849441 52.866671) (xy 86.75 53.1) (xy 86.45 53.1) (xy 86.350559 52.866671) (xy 86.6 52.699)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "7b6edfbb-e096-4f71-8c06-622acba5b9e3")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30124)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 82.150001 135.87145) (xy 81.850001 135.87145) (xy 81.433329 136.050559) (xy 81.6 136.301) (xy 81.849441 136.466671)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 81.849441 136.466671) (xy 81.6 136.301) (xy 81.433329 136.050559) (xy 81.850001 135.87145) (xy 82.150001 135.87145)
+				(xy 92.870564 87.709005) (xy 92.90391 87.717983) (xy 93.385579 87.847669) (xy 93.392676 87.853128)
+				(xy 93.394236 87.858966) (xy 93.394236 88.141033) (xy 93.390809 88.149306) (xy 93.385578 88.152331)
+				(xy 92.870564 88.290994) (xy 92.861684 88.289836) (xy 92.856224 88.282738) (xy 92.856059 88.282039)
+				(xy 92.799469 88.002318) (xy 92.799469 87.99768) (xy 92.856055 87.71798) (xy 92.861054 87.710554)
+				(xy 92.869842 87.708835)
 			)
 		)
 	)
@@ -46874,10 +47691,10 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "7d9eb095-6ac0-4536-9eec-002dae5f65c4")
+		(uuid "7a819348-6deb-42da-94e2-be1b681e6e11")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30023)
+		(priority 30137)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46896,16 +47713,52 @@
 		)
 		(polygon
 			(pts
-				(xy 91.25 69.505764) (xy 90.95 69.505764) (xy 90.805764 70.041473) (xy 91.1 70.101) (xy 91.394236 70.041473)
+				(xy 60.160624 72.672568) (xy 60.160624 72.372568) (xy 59.949441 72.033329) (xy 59.699 72.2) (xy 59.641473 72.494236)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 91.249306 69.509191) (xy 91.252331 69.514422) (xy 91.390994 70.029435) (xy 91.389836 70.038315)
-				(xy 91.382738 70.043775) (xy 91.382016 70.043945) (xy 91.10232 70.10053) (xy 91.09768 70.10053)
-				(xy 90.817983 70.043945) (xy 90.810554 70.038945) (xy 90.808835 70.030157) (xy 90.809005 70.029435)
-				(xy 90.947669 69.514422) (xy 90.953129 69.507324) (xy 90.958967 69.505764) (xy 91.241033 69.505764)
+				(xy 59.955622 72.043269) (xy 59.955815 72.043568) (xy 60.158857 72.369729) (xy 60.160624 72.375912)
+				(xy 60.160624 72.656178) (xy 60.157197 72.664451) (xy 60.148924 72.667878) (xy 60.145123 72.667243)
+				(xy 59.65111 72.497546) (xy 59.644399 72.491618) (xy 59.643428 72.484236) (xy 59.664607 72.375912)
+				(xy 59.698063 72.204788) (xy 59.703013 72.197329) (xy 59.9394 72.04001) (xy 59.948186 72.03828)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "7d585ab5-dd55-4f89-87e8-cafdab3a32bd")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30056)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 89.55 70.805764) (xy 89.25 70.805764) (xy 89.105764 71.341473) (xy 89.4 71.401) (xy 89.694236 71.341473)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 89.694236 71.341473) (xy 89.4 71.401) (xy 89.105764 71.341473) (xy 89.25 70.805764) (xy 89.55 70.805764)
 			)
 		)
 	)
@@ -46945,13 +47798,13 @@
 		)
 	)
 	(zone
-		(net 3)
-		(net_name "GND")
+		(net 1)
+		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "80799af4-62fe-44bf-9674-4506912c95f7")
+		(uuid "7f6ae9b1-cf6b-497e-8140-9fb49d387bb4")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30108)
+		(priority 30042)
 		(attr
 			(teardrop
 				(type padvia)
@@ -46970,53 +47823,16 @@
 		)
 		(polygon
 			(pts
-				(xy 74.833167 96.10079) (xy 74.621035 95.888658) (xy 74.140243 96.165471) (xy 74.306207 96.415619)
-				(xy 74.556355 96.581583)
+				(xy 81.925 55.730764) (xy 81.625 55.730764) (xy 81.480764 56.266473) (xy 81.775 56.326) (xy 82.069236 56.266473)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 74.833167 96.10079) (xy 74.556355 96.581583) (xy 74.306207 96.415619) (xy 74.140243 96.165471)
-				(xy 74.621035 95.888658)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "80e67dde-ca82-4e84-9ee8-e0bf43ceb1c3")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30092)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 49.214122 109.826254) (xy 49.426254 109.614122) (xy 49.149441 109.133329) (xy 48.899293 109.299293)
-				(xy 48.733329 109.549441)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 49.426254 109.614122) (xy 49.214122 109.826254) (xy 48.733329 109.549441) (xy 48.899293 109.299293)
-				(xy 49.149441 109.133329)
+				(xy 81.924306 55.734191) (xy 81.927331 55.739422) (xy 82.065994 56.254435) (xy 82.064836 56.263315)
+				(xy 82.057738 56.268775) (xy 82.057016 56.268945) (xy 81.77732 56.32553) (xy 81.77268 56.32553)
+				(xy 81.492983 56.268945) (xy 81.485554 56.263945) (xy 81.483835 56.255157) (xy 81.484005 56.254435)
+				(xy 81.622669 55.739422) (xy 81.628129 55.732324) (xy 81.633967 55.730764) (xy 81.916033 55.730764)
 			)
 		)
 	)
@@ -47024,10 +47840,10 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "85bd25ab-38fe-4fe2-a1af-78cda006f84f")
+		(uuid "8342a97f-8136-4544-805e-6b9c1df1f6fc")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30032)
+		(priority 30106)
 		(attr
 			(teardrop
 				(type padvia)
@@ -47046,16 +47862,16 @@
 		)
 		(polygon
 			(pts
-				(xy 87.5 83.605764) (xy 87.2 83.605764) (xy 87.105764 84.141473) (xy 87.4 84.201) (xy 87.694236 84.141473)
+				(xy 48.150001 101.494236) (xy 48.45 101.494235) (xy 48.594236 100.958527) (xy 48.3 100.899001) (xy 48.005764 100.958527)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 87.50007 83.609191) (xy 87.502796 83.613476) (xy 87.689608 84.128709) (xy 87.689207 84.137655)
-				(xy 87.682597 84.143696) (xy 87.680929 84.144165) (xy 87.40232 84.20053) (xy 87.39768 84.20053)
-				(xy 87.116943 84.143734) (xy 87.109514 84.138734) (xy 87.10774 84.130239) (xy 87.198298 83.615437)
-				(xy 87.203106 83.607883) (xy 87.209821 83.605764) (xy 87.491797 83.605764)
+				(xy 48.582017 100.956055) (xy 48.589445 100.961054) (xy 48.591164 100.969842) (xy 48.590994 100.970564)
+				(xy 48.452331 101.485577) (xy 48.446871 101.492675) (xy 48.441033 101.494235) (xy 48.158967 101.494235)
+				(xy 48.150694 101.490808) (xy 48.14767 101.485578) (xy 48.009005 100.970564) (xy 48.010163 100.961684)
+				(xy 48.017261 100.956224) (xy 48.017952 100.956061) (xy 48.297682 100.89947) (xy 48.302318 100.89947)
 			)
 		)
 	)
@@ -47063,672 +47879,7 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "8662e55b-00d1-4fc5-975b-c2f03e63015a")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30039)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 78.294236 134.65) (xy 78.294236 134.35) (xy 77.758527 134.205764) (xy 77.699 134.5) (xy 77.758527 134.794236)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 77.770564 134.209005) (xy 77.80391 134.217983) (xy 78.285579 134.347669) (xy 78.292676 134.353128)
-				(xy 78.294236 134.358966) (xy 78.294236 134.641033) (xy 78.290809 134.649306) (xy 78.285578 134.652331)
-				(xy 77.770564 134.790994) (xy 77.761684 134.789836) (xy 77.756224 134.782738) (xy 77.756059 134.782039)
-				(xy 77.699469 134.502318) (xy 77.699469 134.49768) (xy 77.756055 134.21798) (xy 77.761054 134.210554)
-				(xy 77.769842 134.208835)
-			)
-		)
-	)
-	(zone
-		(net 128)
-		(net_name "/MCU/SERVO_FDBK")
-		(layer "F.Cu")
-		(uuid "88cfb7b6-1bf9-484e-a09b-41bf6fcd2828")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30064)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 91.094236 80.15) (xy 91.094236 79.85) (xy 90.558527 79.705764) (xy 90.499 80) (xy 90.558527 80.294236)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 90.570564 79.709005) (xy 90.60391 79.717983) (xy 91.085579 79.847669) (xy 91.092676 79.853128)
-				(xy 91.094236 79.858966) (xy 91.094236 80.141033) (xy 91.090809 80.149306) (xy 91.085578 80.152331)
-				(xy 90.570564 80.290994) (xy 90.561684 80.289836) (xy 90.556224 80.282738) (xy 90.556059 80.282039)
-				(xy 90.499469 80.002318) (xy 90.499469 79.99768) (xy 90.556055 79.71798) (xy 90.561054 79.710554)
-				(xy 90.569842 79.708835)
-			)
-		)
-	)
-	(zone
-		(net 109)
-		(net_name "/MCU/SPI1_MISO")
-		(layer "F.Cu")
-		(uuid "8a200073-dc5e-49c4-8a44-b35aafaeb593")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30134)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 77.281358 114.226081) (xy 77.069226 114.438213) (xy 77.533329 114.749441) (xy 77.700707 114.500707)
-				(xy 77.641473 114.205764)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 77.639794 114.20929) (xy 77.643471 114.215712) (xy 77.699745 114.49592) (xy 77.698014 114.504706)
-				(xy 77.697981 114.504756) (xy 77.53985 114.73975) (xy 77.532388 114.744701) (xy 77.523627 114.742935)
-				(xy 77.081046 114.446139) (xy 77.076083 114.438685) (xy 77.077845 114.429906) (xy 77.079284 114.428154)
-				(xy 77.278202 114.229236) (xy 77.285813 114.225829) (xy 77.631342 114.206335)
-			)
-		)
-	)
-	(zone
-		(net 82)
-		(net_name "/MCU/SPI4_SCK")
-		(layer "F.Cu")
-		(uuid "8c2a873d-f73f-4f27-8a6d-b1f70428349c")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30100)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 82.785878 113.573746) (xy 82.573746 113.785878) (xy 82.850559 114.266671) (xy 83.100707 114.100707)
-				(xy 83.266671 113.850559)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 82.793646 113.578218) (xy 83.078798 113.742392) (xy 83.255867 113.844339) (xy 83.261327 113.851437)
-				(xy 83.260169 113.860317) (xy 83.259778 113.860947) (xy 83.102015 114.098734) (xy 83.098734 114.102015)
-				(xy 82.860947 114.259778) (xy 82.852159 114.261497) (xy 82.84473 114.256497) (xy 82.844339 114.255867)
-				(xy 82.616966 113.860947) (xy 82.578218 113.793646) (xy 82.577061 113.784768) (xy 82.580084 113.779539)
-				(xy 82.779538 113.580085) (xy 82.78781 113.576659)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "8cfe0f73-d1b2-4edf-aa8e-162afdedeb53")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30095)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 82.39829 106.328047) (xy 82.610422 106.115915) (xy 82.333609 105.635122) (xy 82.083461 105.801086)
-				(xy 81.917497 106.051234)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 82.610422 106.115915) (xy 82.39829 106.328047) (xy 81.917497 106.051234) (xy 82.083461 105.801086)
-				(xy 82.333609 105.635122)
-			)
-		)
-	)
-	(zone
-		(net 102)
-		(net_name "/MCU/SPI2_NSS")
-		(layer "F.Cu")
-		(uuid "8e1ce075-42c9-4345-8089-0210ed35e93c")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30028)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 84.65 98.405764) (xy 84.35 98.405764) (xy 84.205764 98.941473) (xy 84.5 99.001) (xy 84.794236 98.941473)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 84.649306 98.409191) (xy 84.652331 98.414422) (xy 84.790994 98.929435) (xy 84.789836 98.938315)
-				(xy 84.782738 98.943775) (xy 84.782016 98.943945) (xy 84.50232 99.00053) (xy 84.49768 99.00053)
-				(xy 84.217983 98.943945) (xy 84.210554 98.938945) (xy 84.208835 98.930157) (xy 84.209005 98.929435)
-				(xy 84.347669 98.414422) (xy 84.353129 98.407324) (xy 84.358967 98.405764) (xy 84.641033 98.405764)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "91cfe1dc-5b1c-4833-8f62-de9c498e7d07")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30024)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 55.994236 80.404208) (xy 55.994236 80.104208) (xy 55.458527 79.905764) (xy 55.399 80.2) (xy 55.458527 80.494236)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 55.471347 79.910513) (xy 55.9866 80.101379) (xy 55.993168 80.107466) (xy 55.994236 80.11235)
-				(xy 55.994236 80.39431) (xy 55.990809 80.402583) (xy 55.984475 80.405848) (xy 55.469689 80.49236)
-				(xy 55.460962 80.490352) (xy 55.456282 80.483143) (xy 55.399469 80.202318) (xy 55.399469 80.19768)
-				(xy 55.455816 79.919161) (xy 55.460815 79.911735) (xy 55.469603 79.910016)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "934899ba-0354-4bb1-a0fd-8854025eecf9")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30056)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 89.55 70.805764) (xy 89.25 70.805764) (xy 89.105764 71.341473) (xy 89.4 71.401) (xy 89.694236 71.341473)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 89.694236 71.341473) (xy 89.4 71.401) (xy 89.105764 71.341473) (xy 89.25 70.805764) (xy 89.55 70.805764)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "94aa4afb-117d-4f05-8a32-77c554b78486")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30014)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 84.243411 57.696964) (xy 84.596964 57.343411) (xy 84.249441 56.933329) (xy 83.999293 57.099293)
-				(xy 83.833329 57.349441)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 84.596964 57.343411) (xy 84.243411 57.696964) (xy 83.833329 57.349441) (xy 83.999293 57.099293)
-				(xy 84.249441 56.933329)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "9609ddbf-d137-47c9-b4e9-fc55f52313ae")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30139)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 92.1 83.249261) (xy 92.4 83.249261) (xy 92.766671 83.049441) (xy 92.6 82.799) (xy 92.305764 82.741473)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 92.595209 82.798063) (xy 92.602671 82.803014) (xy 92.602704 82.803064) (xy 92.759589 83.0388)
-				(xy 92.76132 83.047586) (xy 92.756331 83.055022) (xy 92.755448 83.055556) (xy 92.402617 83.247835)
-				(xy 92.397018 83.249261) (xy 92.117366 83.249261) (xy 92.109093 83.245834) (xy 92.105666 83.237561)
-				(xy 92.106522 83.233167) (xy 92.280806 82.803064) (xy 92.302142 82.75041) (xy 92.308424 82.744031)
-				(xy 92.315227 82.743323)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "97994798-628f-4d0e-9a0b-c25a3be5a2f4")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30050)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 92.805764 83.850001) (xy 92.805764 84.150001) (xy 93.341473 84.294237) (xy 93.401 84.000001)
-				(xy 93.341473 83.705765)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 93.401 84.000001) (xy 93.341473 84.294237) (xy 92.805764 84.150001) (xy 92.805764 83.850001)
-				(xy 93.341473 83.705765)
-			)
-		)
-	)
-	(zone
-		(net 81)
-		(net_name "/MCU/SPI4_NSS")
-		(layer "F.Cu")
-		(uuid "992e0982-5fb7-4094-9d06-80039b88a7c8")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30046)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 86.494236 114.65) (xy 86.494236 114.35) (xy 85.958527 114.205764) (xy 85.899 114.5) (xy 85.958527 114.794236)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 85.970564 114.209005) (xy 86.00391 114.217983) (xy 86.485579 114.347669) (xy 86.492676 114.353128)
-				(xy 86.494236 114.358966) (xy 86.494236 114.641033) (xy 86.490809 114.649306) (xy 86.485578 114.652331)
-				(xy 85.970564 114.790994) (xy 85.961684 114.789836) (xy 85.956224 114.782738) (xy 85.956059 114.782039)
-				(xy 85.899469 114.502318) (xy 85.899469 114.49768) (xy 85.956055 114.21798) (xy 85.961054 114.210554)
-				(xy 85.969842 114.208835)
-			)
-		)
-	)
-	(zone
-		(net 56)
-		(net_name "/Flash/~{CS}")
-		(layer "F.Cu")
-		(uuid "9af65847-df39-48c1-ac1a-3d6cacddca4d")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30098)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 73.826254 111.885878) (xy 73.614122 111.673746) (xy 73.133329 111.950559) (xy 73.299293 112.200707)
-				(xy 73.549441 112.366671)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 73.620462 111.680086) (xy 73.819913 111.879537) (xy 73.82334 111.88781) (xy 73.82178 111.893648)
-				(xy 73.55566 112.355867) (xy 73.548562 112.361327) (xy 73.539682 112.360169) (xy 73.539052 112.359778)
-				(xy 73.301265 112.202015) (xy 73.297984 112.198734) (xy 73.140221 111.960947) (xy 73.138502 111.952159)
-				(xy 73.143502 111.94473) (xy 73.144132 111.944339) (xy 73.606353 111.678218) (xy 73.615231 111.677061)
-			)
-		)
-	)
-	(zone
-		(net 57)
-		(net_name "/MCU/SERVO_EN")
-		(layer "F.Cu")
-		(uuid "9b7e9215-a78e-412b-a203-524fc65a3215")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30065)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 71.405764 74.35) (xy 71.405764 74.65) (xy 71.941473 74.794236) (xy 72.001 74.5) (xy 71.941473 74.205764)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 71.938315 74.210163) (xy 71.943775 74.217261) (xy 71.943945 74.217983) (xy 72.00053 74.49768)
-				(xy 72.00053 74.50232) (xy 71.943945 74.782016) (xy 71.938945 74.789445) (xy 71.930157 74.791164)
-				(xy 71.929435 74.790994) (xy 71.414422 74.652331) (xy 71.407324 74.646871) (xy 71.405764 74.641033)
-				(xy 71.405764 74.358966) (xy 71.409191 74.350693) (xy 71.414419 74.347669) (xy 71.929435 74.209005)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "9bc25c6f-4922-4932-86e8-03548517ddff")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30120)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 86.65 112.85) (xy 86.95 112.85) (xy 87.094236 112.358527) (xy 86.8 112.299) (xy 86.505764 112.358527)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 87.081739 112.355998) (xy 87.089167 112.360998) (xy 87.090886 112.369786) (xy 87.090645 112.370761)
-				(xy 86.952467 112.841595) (xy 86.946849 112.848568) (xy 86.94124 112.85) (xy 86.65876 112.85) (xy 86.650487 112.846573)
-				(xy 86.647533 112.841595) (xy 86.509354 112.370761) (xy 86.510313 112.361857) (xy 86.517286 112.356239)
-				(xy 86.518244 112.356002) (xy 86.797682 112.299469) (xy 86.802318 112.299469)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "9c764a71-275a-406c-94bd-929efb61db5c")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30143)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 81.8848 73.550001) (xy 82.1848 73.550001) (xy 82.294236 73.158527) (xy 82 73.099) (xy 81.750559 73.266671)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 82.004789 73.099969) (xy 82.281899 73.156031) (xy 82.289328 73.161031) (xy 82.291047 73.169819)
-				(xy 82.290847 73.170649) (xy 82.18719 73.541451) (xy 82.181662 73.548496) (xy 82.175922 73.550001)
-				(xy 81.892203 73.550001) (xy 81.88393 73.546574) (xy 81.88163 73.543311) (xy 81.754871 73.275772)
-				(xy 81.754425 73.266828) (xy 81.758915 73.261053) (xy 81.995943 73.101726) (xy 82.00472 73.099956)
-			)
-		)
-	)
-	(zone
-		(net 49)
-		(net_name "/MCU/BOOT0")
-		(layer "F.Cu")
-		(uuid "9e9eaf96-6bc4-4388-86aa-9a0cb5cd6549")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30076)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 65.05 100.894236) (xy 65.35 100.894236) (xy 65.494236 100.358527) (xy 65.2 100.299) (xy 64.905764 100.358527)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 65.482017 100.356055) (xy 65.489445 100.361054) (xy 65.491164 100.369842) (xy 65.490994 100.370564)
-				(xy 65.352331 100.885578) (xy 65.346871 100.892676) (xy 65.341033 100.894236) (xy 65.058967 100.894236)
-				(xy 65.050694 100.890809) (xy 65.047669 100.885578) (xy 64.909005 100.370564) (xy 64.910163 100.361684)
-				(xy 64.917261 100.356224) (xy 64.917953 100.35606) (xy 65.197682 100.299469) (xy 65.202318 100.299469)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "9ffec7c7-863c-43e6-9094-6478478ec8b5")
+		(uuid "83e21d62-2507-4737-90a3-06e506c0a15e")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30043)
@@ -47765,13 +47916,13 @@
 		)
 	)
 	(zone
-		(net 3)
-		(net_name "GND")
+		(net 1)
+		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "a04d7e9a-5c41-445d-bf44-98e16a961dd6")
+		(uuid "869dd9b4-8d14-4983-a012-40c40335fc00")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30059)
+		(priority 30123)
 		(attr
 			(teardrop
 				(type padvia)
@@ -47790,13 +47941,98 @@
 		)
 		(polygon
 			(pts
-				(xy 72.116726 68.005764) (xy 71.816726 68.005764) (xy 71.705764 68.541473) (xy 72 68.601) (xy 72.294236 68.541473)
+				(xy 83.149999 136.816113) (xy 83.449999 136.816113) (xy 83.394236 136.241473) (xy 83.1 136.299)
+				(xy 82.850559 136.466671)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 72.294236 68.541473) (xy 72 68.601) (xy 71.705764 68.541473) (xy 71.816726 68.005764) (xy 72.116726 68.005764)
+				(xy 83.390367 136.245721) (xy 83.395318 136.253183) (xy 83.39548 136.254298) (xy 83.448754 136.803283)
+				(xy 83.446143 136.811848) (xy 83.438239 136.816058) (xy 83.437109 136.816113) (xy 83.155381 136.816113)
+				(xy 83.147108 136.812686) (xy 83.146497 136.812026) (xy 82.859116 136.476657) (xy 82.856335 136.468145)
+				(xy 82.860387 136.46016) (xy 82.861464 136.45934) (xy 83.09804 136.300317) (xy 83.102314 136.298547)
+				(xy 83.381591 136.243945)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "897f3573-ebf7-4bd1-a286-6bd4988391f8")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30139)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 92.1 83.249261) (xy 92.4 83.249261) (xy 92.766671 83.049441) (xy 92.6 82.799) (xy 92.305764 82.741473)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 92.595209 82.798063) (xy 92.602671 82.803014) (xy 92.602704 82.803064) (xy 92.759589 83.0388)
+				(xy 92.76132 83.047586) (xy 92.756331 83.055022) (xy 92.755448 83.055556) (xy 92.402617 83.247835)
+				(xy 92.397018 83.249261) (xy 92.117366 83.249261) (xy 92.109093 83.245834) (xy 92.105666 83.237561)
+				(xy 92.106522 83.233167) (xy 92.280806 82.803064) (xy 92.302142 82.75041) (xy 92.308424 82.744031)
+				(xy 92.315227 82.743323)
+			)
+		)
+	)
+	(zone
+		(net 102)
+		(net_name "/MCU/SPI2_NSS")
+		(layer "F.Cu")
+		(uuid "89c3aeaf-1a02-4283-b35d-3327f6a2512f")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30103)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 86.223746 101.564122) (xy 86.435878 101.776254) (xy 86.916671 101.499441) (xy 86.750707 101.249293)
+				(xy 86.500559 101.083329)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 86.510317 101.08983) (xy 86.510947 101.090221) (xy 86.748734 101.247984) (xy 86.752015 101.251265)
+				(xy 86.909778 101.489052) (xy 86.911497 101.49784) (xy 86.906497 101.505269) (xy 86.905867 101.50566)
+				(xy 86.443648 101.77178) (xy 86.434768 101.772938) (xy 86.429537 101.769913) (xy 86.230086 101.570462)
+				(xy 86.226659 101.562189) (xy 86.228218 101.556354) (xy 86.494339 101.094131) (xy 86.501437 101.088672)
 			)
 		)
 	)
@@ -47804,10 +48040,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "a100e7be-3f32-46c9-ba95-9955e5721255")
+		(uuid "8c721cb8-d49b-43d8-8e89-a1429f50332f")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30118)
+		(priority 30133)
 		(attr
 			(teardrop
 				(type padvia)
@@ -47826,13 +48062,479 @@
 		)
 		(polygon
 			(pts
-				(xy 91.75 61.85) (xy 91.75 61.55) (xy 91.258527 61.405764) (xy 91.199 61.7) (xy 91.258527 61.994236)
+				(xy 91.4 85.809318) (xy 91.1 85.809318) (xy 91.205764 86.358527) (xy 91.5 86.301) (xy 91.666671 86.050559)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 91.75 61.55) (xy 91.75 61.85) (xy 91.258527 61.994236) (xy 91.199 61.7) (xy 91.258527 61.405764)
+				(xy 91.666671 86.050559) (xy 91.5 86.301) (xy 91.205764 86.358527) (xy 91.1 85.809318) (xy 91.4 85.809318)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "8f8ec5ac-25c8-4f65-8eee-24097c592cc4")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30112)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 64.60079 103.666833) (xy 64.388658 103.878965) (xy 64.665471 104.359757) (xy 64.915619 104.193793)
+				(xy 65.081583 103.943645)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 65.081583 103.943645) (xy 64.915619 104.193793) (xy 64.665471 104.359757) (xy 64.388658 103.878965)
+				(xy 64.60079 103.666833)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "912ddc7a-0771-4986-8065-cce64b014c9c")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30008)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 94.75 138.505764) (xy 94.25 138.505764) (xy 94.205764 139.041473) (xy 94.5 139.101) (xy 94.794236 139.041473)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 94.7475 138.509191) (xy 94.750887 138.516501) (xy 94.793379 139.031104) (xy 94.790645 139.039631)
+				(xy 94.784039 139.043535) (xy 94.50232 139.10053) (xy 94.49768 139.10053) (xy 94.21596 139.043535)
+				(xy 94.208531 139.038535) (xy 94.20662 139.031104) (xy 94.249113 138.516501) (xy 94.253209 138.508538)
+				(xy 94.260773 138.505764) (xy 94.739227 138.505764)
+			)
+		)
+	)
+	(zone
+		(net 108)
+		(net_name "/MCU/MAG_INT")
+		(layer "F.Cu")
+		(uuid "91bdf97b-f3b6-45a6-8a2b-a8598620edd0")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30109)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 85.851676 119.288699) (xy 86.063808 119.076567) (xy 85.786996 118.595774) (xy 85.536848 118.761738)
+				(xy 85.370884 119.011886)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 85.792824 118.605947) (xy 85.793215 118.606577) (xy 86.059334 119.068796) (xy 86.060492 119.077676)
+				(xy 86.057467 119.082907) (xy 85.858016 119.282358) (xy 85.849743 119.285785) (xy 85.843905 119.284225)
+				(xy 85.381687 119.018105) (xy 85.376227 119.011007) (xy 85.377385 119.002127) (xy 85.377765 119.001513)
+				(xy 85.53554 118.763708) (xy 85.538818 118.76043) (xy 85.776608 118.602665) (xy 85.785395 118.600947)
+			)
+		)
+	)
+	(zone
+		(net 57)
+		(net_name "/MCU/SERVO_EN")
+		(layer "F.Cu")
+		(uuid "923471b8-4343-4e0f-8f83-ea81494db13c")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30063)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 61.45 97.094236) (xy 61.75 97.094236) (xy 61.894236 96.558527) (xy 61.6 96.499) (xy 61.305764 96.558527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 61.882017 96.556055) (xy 61.889445 96.561054) (xy 61.891164 96.569842) (xy 61.890994 96.570564)
+				(xy 61.752331 97.085578) (xy 61.746871 97.092676) (xy 61.741033 97.094236) (xy 61.458967 97.094236)
+				(xy 61.450694 97.090809) (xy 61.447669 97.085578) (xy 61.309005 96.570564) (xy 61.310163 96.561684)
+				(xy 61.317261 96.556224) (xy 61.317953 96.55606) (xy 61.597682 96.499469) (xy 61.602318 96.499469)
+			)
+		)
+	)
+	(zone
+		(net 128)
+		(net_name "/MCU/SERVO_FDBK")
+		(layer "F.Cu")
+		(uuid "92e329db-228f-4a83-b1b5-9607f9d152e6")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30066)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 78.85 103.594236) (xy 79.15 103.594236) (xy 79.294236 103.058527) (xy 79 102.999) (xy 78.705764 103.058527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 79.282017 103.056055) (xy 79.289445 103.061054) (xy 79.291164 103.069842) (xy 79.290994 103.070564)
+				(xy 79.152331 103.585578) (xy 79.146871 103.592676) (xy 79.141033 103.594236) (xy 78.858967 103.594236)
+				(xy 78.850694 103.590809) (xy 78.847669 103.585578) (xy 78.709005 103.070564) (xy 78.710163 103.061684)
+				(xy 78.717261 103.056224) (xy 78.717953 103.05606) (xy 78.997682 102.999469) (xy 79.002318 102.999469)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "94866f82-9557-4bc0-a650-4c20a4e74442")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30124)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 82.150001 135.87145) (xy 81.850001 135.87145) (xy 81.433329 136.050559) (xy 81.6 136.301) (xy 81.849441 136.466671)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 81.849441 136.466671) (xy 81.6 136.301) (xy 81.433329 136.050559) (xy 81.850001 135.87145) (xy 82.150001 135.87145)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "949d519b-426a-4738-b69b-e8e6fd30c459")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30089)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 66.683619 128.823995) (xy 66.895751 129.036127) (xy 67.376544 128.759314) (xy 67.21058 128.509166)
+				(xy 66.960432 128.343202)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 66.97019 128.349703) (xy 66.97082 128.350094) (xy 67.208607 128.507857) (xy 67.211888 128.511138)
+				(xy 67.369651 128.748925) (xy 67.37137 128.757713) (xy 67.36637 128.765142) (xy 67.36574 128.765533)
+				(xy 66.903521 129.031653) (xy 66.894641 129.032811) (xy 66.88941 129.029786) (xy 66.689959 128.830335)
+				(xy 66.686532 128.822062) (xy 66.688091 128.816227) (xy 66.954212 128.354004) (xy 66.96131 128.348545)
+			)
+		)
+	)
+	(zone
+		(net 108)
+		(net_name "/MCU/MAG_INT")
+		(layer "F.Cu")
+		(uuid "94e8d071-7936-4f6d-84de-080a1adee2d0")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30081)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 79.121229 109.419148) (xy 79.333361 109.207016) (xy 79.049441 108.733329) (xy 78.799293 108.899293)
+				(xy 78.633329 109.149441)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 79.055451 108.743381) (xy 79.055737 108.743834) (xy 79.328666 109.199184) (xy 79.32998 109.208042)
+				(xy 79.326904 109.213472) (xy 79.127455 109.412921) (xy 79.119182 109.416348) (xy 79.113523 109.414888)
+				(xy 78.644431 109.155578) (xy 78.638848 109.148576) (xy 78.639851 109.139678) (xy 78.640342 109.13887)
+				(xy 78.797985 108.901263) (xy 78.801263 108.897985) (xy 79.039236 108.740099) (xy 79.048022 108.738381)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "975af09e-aed4-47aa-abb2-282593ccde64")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30012)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 84.45 50.794236) (xy 84.95 50.794236) (xy 84.994236 50.258527) (xy 84.7 50.199) (xy 84.405764 50.258527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 84.994236 50.258527) (xy 84.95 50.794236) (xy 84.45 50.794236) (xy 84.405764 50.258527) (xy 84.7 50.199)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "9dcb97ed-1d52-4de2-8b80-bdfceaa12dba")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30131)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 50.606822 83.206026) (xy 50.606822 83.506026) (xy 50.850559 83.766671) (xy 51.101 83.6) (xy 51.158527 83.305764)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 50.620599 83.208516) (xy 51.146848 83.303652) (xy 51.154379 83.308496) (xy 51.156279 83.317246)
+				(xy 51.156249 83.31741) (xy 51.101936 83.595209) (xy 51.096985 83.602671) (xy 51.096935 83.602704)
+				(xy 50.858814 83.761177) (xy 50.850028 83.762908) (xy 50.843786 83.759428) (xy 50.609976 83.509398)
+				(xy 50.606822 83.501407) (xy 50.606822 83.22003) (xy 50.610249 83.211757) (xy 50.618522 83.20833)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "9e1a97cf-0594-41bd-a8bd-d9abbfee2a99")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30003)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 108.705764 141.75) (xy 108.705764 142.25) (xy 109.241473 142.294236) (xy 109.301 142) (xy 109.241473 141.705764)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 109.239631 141.709354) (xy 109.243535 141.71596) (xy 109.30053 141.99768) (xy 109.30053 142.00232)
+				(xy 109.243535 142.284039) (xy 109.238535 142.291468) (xy 109.231104 142.293379) (xy 108.716501 142.250886)
+				(xy 108.708538 142.24679) (xy 108.705764 142.239226) (xy 108.705764 141.760773) (xy 108.709191 141.7525)
+				(xy 108.716499 141.749113) (xy 109.231104 141.70662)
+			)
+		)
+	)
+	(zone
+		(net 75)
+		(net_name "/MCU/IMU_INT2")
+		(layer "F.Cu")
+		(uuid "a0e73609-403b-4761-b137-908746c3908e")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30099)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 91.435878 81.723747) (xy 91.223746 81.935879) (xy 91.500559 82.416672) (xy 91.750707 82.250708)
+				(xy 91.916671 82.00056)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 91.443646 81.728219) (xy 91.728798 81.892393) (xy 91.905867 81.99434) (xy 91.911327 82.001438)
+				(xy 91.910169 82.010318) (xy 91.909778 82.010948) (xy 91.752015 82.248735) (xy 91.748734 82.252016)
+				(xy 91.510947 82.409779) (xy 91.502159 82.411498) (xy 91.49473 82.406498) (xy 91.494339 82.405868)
+				(xy 91.266966 82.010948) (xy 91.228218 81.943647) (xy 91.227061 81.934769) (xy 91.230084 81.92954)
+				(xy 91.429538 81.730086) (xy 91.43781 81.72666)
 			)
 		)
 	)
@@ -47875,91 +48577,13 @@
 		)
 	)
 	(zone
-		(net 3)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "a214e528-9ec4-4410-a430-2e0a344be696")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30126)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 94.087345 84.074786) (xy 93.875214 83.862655) (xy 93.458527 83.705765) (xy 93.399293 84.000708)
-				(xy 93.458527 84.294237)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 93.875214 83.862655) (xy 94.087345 84.074786) (xy 93.458527 84.294237) (xy 93.399293 84.000708)
-				(xy 93.458527 83.705765)
-			)
-		)
-	)
-	(zone
-		(net 84)
-		(net_name "/MCU/SPI1_MOSI")
-		(layer "F.Cu")
-		(uuid "a7d41011-4a6b-4fdf-998c-d6ea78eaa487")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30101)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 81.114122 116.826254) (xy 81.326254 116.614122) (xy 81.049441 116.133329) (xy 80.799293 116.299293)
-				(xy 80.633329 116.549441)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 81.055269 116.143502) (xy 81.05566 116.144132) (xy 81.32178 116.606351) (xy 81.322938 116.615231)
-				(xy 81.319913 116.620462) (xy 81.120462 116.819913) (xy 81.112189 116.82334) (xy 81.106351 116.82178)
-				(xy 80.644132 116.55566) (xy 80.638672 116.548562) (xy 80.63983 116.539682) (xy 80.64021 116.539068)
-				(xy 80.797985 116.301263) (xy 80.801263 116.297985) (xy 81.039053 116.14022) (xy 81.04784 116.138502)
-			)
-		)
-	)
-	(zone
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "a8746c69-1758-49d6-aeb9-ed4d40a77ec5")
+		(uuid "a69ae876-2538-4ec6-b1c0-5c7305f8a2fd")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30140)
+		(priority 30023)
 		(attr
 			(teardrop
 				(type padvia)
@@ -47978,140 +48602,16 @@
 		)
 		(polygon
 			(pts
-				(xy 83.134036 135.840594) (xy 82.921905 135.628463) (xy 82.805764 136.241473) (xy 83.099293 136.300707)
-				(xy 83.349441 136.133329)
+				(xy 91.25 69.505764) (xy 90.95 69.505764) (xy 90.805764 70.041473) (xy 91.1 70.101) (xy 91.394236 70.041473)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 82.937554 135.644112) (xy 83.133408 135.839966) (xy 83.134559 135.841305) (xy 83.34219 136.123475)
-				(xy 83.344333 136.132169) (xy 83.3397 136.139833) (xy 83.339272 136.140133) (xy 83.10334 136.297998)
-				(xy 83.094559 136.299751) (xy 83.09452 136.299743) (xy 82.817098 136.24376) (xy 82.809666 136.238764)
-				(xy 82.807916 136.230113) (xy 82.824964 136.140133) (xy 82.917785 135.650206) (xy 82.922692 135.642716)
-				(xy 82.931459 135.640889)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "a9237151-c2e4-49e8-929e-b310aee5faad")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30110)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 83.828519 106.631106) (xy 83.616387 106.843238) (xy 83.893199 107.324031) (xy 84.143347 107.158067)
-				(xy 84.309311 106.907919)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 83.836287 106.635578) (xy 84.119078 106.798393) (xy 84.298507 106.901699) (xy 84.303967 106.908797)
-				(xy 84.302809 106.917677) (xy 84.302418 106.918307) (xy 84.144655 107.156094) (xy 84.141374 107.159375)
-				(xy 83.903587 107.317138) (xy 83.894799 107.318857) (xy 83.88737 107.313857) (xy 83.886979 107.313227)
-				(xy 83.659607 106.918307) (xy 83.620859 106.851006) (xy 83.619702 106.842128) (xy 83.622725 106.836899)
-				(xy 83.822179 106.637445) (xy 83.830451 106.634019)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "a98e9be2-c601-4b90-9a56-8c152219f102")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30088)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 54.285878 73.973746) (xy 54.073746 74.185878) (xy 54.350559 74.666671) (xy 54.600707 74.500707)
-				(xy 54.766671 74.250559)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 54.293646 73.978218) (xy 54.578798 74.142392) (xy 54.755867 74.244339) (xy 54.761327 74.251437)
-				(xy 54.760169 74.260317) (xy 54.759778 74.260947) (xy 54.602015 74.498734) (xy 54.598734 74.502015)
-				(xy 54.360947 74.659778) (xy 54.352159 74.661497) (xy 54.34473 74.656497) (xy 54.344339 74.655867)
-				(xy 54.116966 74.260947) (xy 54.078218 74.193646) (xy 54.077061 74.184768) (xy 54.080084 74.179539)
-				(xy 54.279538 73.980085) (xy 54.28781 73.976659)
-			)
-		)
-	)
-	(zone
-		(net 116)
-		(net_name "/MCU/SPI1_SCK")
-		(layer "F.Cu")
-		(uuid "aaf0b236-5e90-4988-8be9-97324ffd6247")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30086)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 82.814122 126.026254) (xy 83.026254 125.814122) (xy 82.749441 125.333329) (xy 82.499293 125.499293)
-				(xy 82.333329 125.749441)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 82.755269 125.343502) (xy 82.75566 125.344132) (xy 83.02178 125.806351) (xy 83.022938 125.815231)
-				(xy 83.019913 125.820462) (xy 82.820462 126.019913) (xy 82.812189 126.02334) (xy 82.806351 126.02178)
-				(xy 82.344132 125.75566) (xy 82.338672 125.748562) (xy 82.33983 125.739682) (xy 82.34021 125.739068)
-				(xy 82.497985 125.501263) (xy 82.501263 125.497985) (xy 82.739053 125.34022) (xy 82.74784 125.338502)
+				(xy 91.249306 69.509191) (xy 91.252331 69.514422) (xy 91.390994 70.029435) (xy 91.389836 70.038315)
+				(xy 91.382738 70.043775) (xy 91.382016 70.043945) (xy 91.10232 70.10053) (xy 91.09768 70.10053)
+				(xy 90.817983 70.043945) (xy 90.810554 70.038945) (xy 90.808835 70.030157) (xy 90.809005 70.029435)
+				(xy 90.947669 69.514422) (xy 90.953129 69.507324) (xy 90.958967 69.505764) (xy 91.241033 69.505764)
 			)
 		)
 	)
@@ -48119,10 +48619,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "b01db5b4-59d5-46eb-ba35-9c3a34f37583")
+		(uuid "a790c9be-b329-46ce-ad86-e038871088cd")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30132)
+		(priority 30001)
 		(attr
 			(teardrop
 				(type padvia)
@@ -48141,24 +48641,26 @@
 		)
 		(polygon
 			(pts
-				(xy 91.9 85.809318) (xy 91.6 85.809318) (xy 91.333329 86.050559) (xy 91.5 86.301) (xy 91.794236 86.358527)
+				(xy 82.699999 146.005764) (xy 82.199999 146.005764) (xy 82.205764 146.658527) (xy 82.5 146.601)
+				(xy 82.794236 146.541473)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 91.794236 86.358527) (xy 91.5 86.301) (xy 91.333329 86.050559) (xy 91.6 85.809318) (xy 91.9 85.809318)
+				(xy 82.794236 146.541473) (xy 82.5 146.601) (xy 82.205764 146.658527) (xy 82.199999 146.005764)
+				(xy 82.699999 146.005764)
 			)
 		)
 	)
 	(zone
-		(net 1)
-		(net_name "+3V3")
+		(net 13)
+		(net_name "/MCU/BATT_VSENSE")
 		(layer "F.Cu")
-		(uuid "b02dcfba-808c-4784-a103-1f2d0dd8895b")
+		(uuid "a909cecd-1369-4864-8dc4-1262482ba5b6")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30038)
+		(priority 30067)
 		(attr
 			(teardrop
 				(type padvia)
@@ -48177,28 +48679,28 @@
 		)
 		(polygon
 			(pts
-				(xy 86.961799 120.005764) (xy 86.661799 120.005764) (xy 86.505764 120.541473) (xy 86.8 120.601)
-				(xy 87.094236 120.541473)
+				(xy 93.394236 76.55) (xy 93.394236 76.25) (xy 92.858527 76.105764) (xy 92.799 76.4) (xy 92.858527 76.694236)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 86.960912 120.009191) (xy 86.963997 120.014656) (xy 87.091305 120.529618) (xy 87.089964 120.538472)
-				(xy 87.082755 120.543784) (xy 87.082267 120.543894) (xy 86.80232 120.60053) (xy 86.79768 120.60053)
-				(xy 86.518235 120.543996) (xy 86.510806 120.538996) (xy 86.509087 120.530208) (xy 86.509322 120.529256)
-				(xy 86.659344 120.014192) (xy 86.664947 120.007207) (xy 86.670577 120.005764) (xy 86.952639 120.005764)
+				(xy 92.870564 76.109005) (xy 92.90391 76.117983) (xy 93.385579 76.247669) (xy 93.392676 76.253128)
+				(xy 93.394236 76.258966) (xy 93.394236 76.541033) (xy 93.390809 76.549306) (xy 93.385578 76.552331)
+				(xy 92.870564 76.690994) (xy 92.861684 76.689836) (xy 92.856224 76.682738) (xy 92.856059 76.682039)
+				(xy 92.799469 76.402318) (xy 92.799469 76.39768) (xy 92.856055 76.11798) (xy 92.861054 76.110554)
+				(xy 92.869842 76.108835)
 			)
 		)
 	)
 	(zone
-		(net 75)
-		(net_name "/MCU/IMU_INT2")
+		(net 49)
+		(net_name "/MCU/BOOT0")
 		(layer "F.Cu")
-		(uuid "b0986411-8add-4f84-95c6-a5c95deb13aa")
+		(uuid "aa17fba7-b0bf-4d48-80f6-0ba7f57c322d")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30051)
+		(priority 30077)
 		(attr
 			(teardrop
 				(type padvia)
@@ -48217,55 +48719,16 @@
 		)
 		(polygon
 			(pts
-				(xy 82.35 100.594236) (xy 82.65 100.594236) (xy 82.794236 100.058527) (xy 82.5 99.999) (xy 82.205764 100.058527)
+				(xy 61.905764 104.15) (xy 61.905764 104.45) (xy 62.441473 104.594236) (xy 62.501 104.3) (xy 62.441473 104.005764)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 82.782017 100.056055) (xy 82.789445 100.061054) (xy 82.791164 100.069842) (xy 82.790994 100.070564)
-				(xy 82.652331 100.585578) (xy 82.646871 100.592676) (xy 82.641033 100.594236) (xy 82.358967 100.594236)
-				(xy 82.350694 100.590809) (xy 82.347669 100.585578) (xy 82.209005 100.070564) (xy 82.210163 100.061684)
-				(xy 82.217261 100.056224) (xy 82.217953 100.05606) (xy 82.497682 99.999469) (xy 82.502318 99.999469)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "b16ae56f-f86e-4c49-bd17-66036ff9ce4f")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30040)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 89.705764 69.05) (xy 89.705764 69.35) (xy 90.241473 69.494236) (xy 90.301 69.2) (xy 90.241473 68.905764)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 90.238315 68.910163) (xy 90.243775 68.917261) (xy 90.243945 68.917983) (xy 90.30053 69.19768)
-				(xy 90.30053 69.20232) (xy 90.243945 69.482016) (xy 90.238945 69.489445) (xy 90.230157 69.491164)
-				(xy 90.229435 69.490994) (xy 89.714422 69.352331) (xy 89.707324 69.346871) (xy 89.705764 69.341033)
-				(xy 89.705764 69.058966) (xy 89.709191 69.050693) (xy 89.714419 69.047669) (xy 90.229435 68.909005)
+				(xy 62.438315 104.010163) (xy 62.443775 104.017261) (xy 62.443945 104.017983) (xy 62.50053 104.29768)
+				(xy 62.50053 104.30232) (xy 62.443945 104.582016) (xy 62.438945 104.589445) (xy 62.430157 104.591164)
+				(xy 62.429435 104.590994) (xy 61.914422 104.452331) (xy 61.907324 104.446871) (xy 61.905764 104.441033)
+				(xy 61.905764 104.158966) (xy 61.909191 104.150693) (xy 61.914419 104.147669) (xy 62.429435 104.009005)
 			)
 		)
 	)
@@ -48273,10 +48736,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "b22d5aa2-db0e-46e3-96d8-3d4b39c9873a")
+		(uuid "ada97ec4-e75a-48fb-b54d-36fd8d2a5a08")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30061)
+		(priority 30015)
 		(attr
 			(teardrop
 				(type padvia)
@@ -48295,250 +48758,15 @@
 		)
 		(polygon
 			(pts
-				(xy 92.2 71.805764) (xy 91.9 71.805764) (xy 91.805764 72.341473) (xy 92.1 72.401) (xy 92.394236 72.341473)
+				(xy 85.096964 55.956589) (xy 84.743411 55.603036) (xy 84.333329 55.950559) (xy 84.499293 56.200707)
+				(xy 84.749441 56.366671)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 92.394236 72.341473) (xy 92.1 72.401) (xy 91.805764 72.341473) (xy 91.9 71.805764) (xy 92.2 71.805764)
-			)
-		)
-	)
-	(zone
-		(net 108)
-		(net_name "/MCU/MAG_INT")
-		(layer "F.Cu")
-		(uuid "b6b95b63-8c00-4b82-937b-627fba8f75a9")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30136)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 85.399999 118.287319) (xy 85.099999 118.287319) (xy 85.243319 118.820972) (xy 85.537555 118.763445)
-				(xy 85.704226 118.513004)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 85.403103 118.289622) (xy 85.695297 118.50638) (xy 85.6999 118.514062) (xy 85.698066 118.522259)
-				(xy 85.540259 118.75938) (xy 85.532823 118.764369) (xy 85.532764 118.764381) (xy 85.254032 118.818877)
-				(xy 85.245255 118.817101) (xy 85.240487 118.81043) (xy 85.103956 118.302053) (xy 85.10512 118.293175)
-				(xy 85.112221 118.287719) (xy 85.115256 118.287319) (xy 85.396132 118.287319)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "b8f5a9bf-49dd-4842-b467-6da720ac2045")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30045)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 86.661799 122.994236) (xy 86.961799 122.994236) (xy 87.106035 122.458527) (xy 86.811799 122.399)
-				(xy 86.517563 122.458527)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 87.093816 122.456055) (xy 87.101244 122.461054) (xy 87.102963 122.469842) (xy 87.102793 122.470564)
-				(xy 86.96413 122.985578) (xy 86.95867 122.992676) (xy 86.952832 122.994236) (xy 86.670766 122.994236)
-				(xy 86.662493 122.990809) (xy 86.659468 122.985578) (xy 86.520804 122.470564) (xy 86.521962 122.461684)
-				(xy 86.52906 122.456224) (xy 86.529752 122.45606) (xy 86.809481 122.399469) (xy 86.814117 122.399469)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "ba20274c-02bc-41dd-a4da-6130c9f0e0d1")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30131)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 50.606822 83.206026) (xy 50.606822 83.506026) (xy 50.850559 83.766671) (xy 51.101 83.6) (xy 51.158527 83.305764)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 50.620599 83.208516) (xy 51.146848 83.303652) (xy 51.154379 83.308496) (xy 51.156279 83.317246)
-				(xy 51.156249 83.31741) (xy 51.101936 83.595209) (xy 51.096985 83.602671) (xy 51.096935 83.602704)
-				(xy 50.858814 83.761177) (xy 50.850028 83.762908) (xy 50.843786 83.759428) (xy 50.609976 83.509398)
-				(xy 50.606822 83.501407) (xy 50.606822 83.22003) (xy 50.610249 83.211757) (xy 50.618522 83.20833)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "bb75ef22-1fd9-4f6e-8681-17169228cdd1")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30106)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 48.150001 101.494236) (xy 48.45 101.494235) (xy 48.594236 100.958527) (xy 48.3 100.899001) (xy 48.005764 100.958527)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 48.582017 100.956055) (xy 48.589445 100.961054) (xy 48.591164 100.969842) (xy 48.590994 100.970564)
-				(xy 48.452331 101.485577) (xy 48.446871 101.492675) (xy 48.441033 101.494235) (xy 48.158967 101.494235)
-				(xy 48.150694 101.490808) (xy 48.14767 101.485578) (xy 48.009005 100.970564) (xy 48.010163 100.961684)
-				(xy 48.017261 100.956224) (xy 48.017952 100.956061) (xy 48.297682 100.89947) (xy 48.302318 100.89947)
-			)
-		)
-	)
-	(zone
-		(net 87)
-		(net_name "/MCU/BATT_ISENSE")
-		(layer "F.Cu")
-		(uuid "bcaeaea3-6024-4f5d-a5ff-2ff43cae0266")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30030)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 77.85 103.094236) (xy 78.15 103.094236) (xy 78.294236 102.558527) (xy 78 102.499) (xy 77.705764 102.558527)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 78.282017 102.556055) (xy 78.289445 102.561054) (xy 78.291164 102.569842) (xy 78.290994 102.570564)
-				(xy 78.152331 103.085578) (xy 78.146871 103.092676) (xy 78.141033 103.094236) (xy 77.858967 103.094236)
-				(xy 77.850694 103.090809) (xy 77.847669 103.085578) (xy 77.709005 102.570564) (xy 77.710163 102.561684)
-				(xy 77.717261 102.556224) (xy 77.717953 102.55606) (xy 77.997682 102.499469) (xy 78.002318 102.499469)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "be3ed957-cff5-4fb6-9c2d-843d6c917797")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30035)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 90.894236 69.375) (xy 90.894236 69.075) (xy 90.358527 68.905764) (xy 90.299 69.2) (xy 90.358527 69.494236)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 90.370929 68.909681) (xy 90.88606 69.072417) (xy 90.892917 69.078177) (xy 90.894236 69.083574)
-				(xy 90.894236 69.365617) (xy 90.890809 69.37389) (xy 90.885078 69.377038) (xy 90.370171 69.491644)
-				(xy 90.361351 69.490096) (xy 90.356208 69.482765) (xy 90.356161 69.482543) (xy 90.334816 69.377038)
-				(xy 90.299469 69.202318) (xy 90.299469 69.19768) (xy 90.322554 69.083574) (xy 90.355946 68.918518)
-				(xy 90.360945 68.911092) (xy 90.369733 68.909373)
+				(xy 85.096964 55.956589) (xy 84.749441 56.366671) (xy 84.499293 56.200707) (xy 84.333329 55.950559)
+				(xy 84.743411 55.603036)
 			)
 		)
 	)
@@ -48546,10 +48774,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "c0f9d9c4-73cd-49a8-9fa0-ff678ca36e56")
+		(uuid "b011aecf-5185-4658-a4db-073b4fb02973")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30034)
+		(priority 30068)
 		(attr
 			(teardrop
 				(type padvia)
@@ -48568,13 +48796,13 @@
 		)
 		(polygon
 			(pts
-				(xy 76.85 92.394236) (xy 77.15 92.394236) (xy 77.294236 91.858527) (xy 77 91.799) (xy 76.705764 91.858527)
+				(xy 81.694236 139.1125) (xy 81.694236 138.8125) (xy 81.158527 138.705764) (xy 81.099 139) (xy 81.158527 139.294236)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 77.294236 91.858527) (xy 77.15 92.394236) (xy 76.85 92.394236) (xy 76.705764 91.858527) (xy 77 91.799)
+				(xy 81.694236 138.8125) (xy 81.694236 139.1125) (xy 81.158527 139.294236) (xy 81.099 139) (xy 81.158527 138.705764)
 			)
 		)
 	)
@@ -48582,10 +48810,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "c10ee43c-bfa9-4164-8b7b-38b195fd9ad6")
+		(uuid "b146452c-5f91-4e7e-a40e-0f12a2398841")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30091)
+		(priority 30093)
 		(attr
 			(teardrop
 				(type padvia)
@@ -48604,26 +48832,26 @@
 		)
 		(polygon
 			(pts
-				(xy 78.414122 67.726254) (xy 78.626254 67.514122) (xy 78.349441 67.033329) (xy 78.099293 67.199293)
-				(xy 77.933329 67.449441)
+				(xy 72.185878 134.173746) (xy 71.973746 134.385878) (xy 72.250559 134.866671) (xy 72.500707 134.700707)
+				(xy 72.666671 134.450559)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 78.626254 67.514122) (xy 78.414122 67.726254) (xy 77.933329 67.449441) (xy 78.099293 67.199293)
-				(xy 78.349441 67.033329)
+				(xy 72.666671 134.450559) (xy 72.500707 134.700707) (xy 72.250559 134.866671) (xy 71.973746 134.385878)
+				(xy 72.185878 134.173746)
 			)
 		)
 	)
 	(zone
-		(net 12)
-		(net_name "Net-(U2-SW)")
+		(net 128)
+		(net_name "/MCU/SERVO_FDBK")
 		(layer "F.Cu")
-		(uuid "c254865d-f519-4589-8376-878a7b90f17b")
+		(uuid "b1589774-f6bf-4b3e-96a8-1850ff600739")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30041)
+		(priority 30064)
 		(attr
 			(teardrop
 				(type padvia)
@@ -48642,24 +48870,28 @@
 		)
 		(polygon
 			(pts
-				(xy 86.705764 53.45) (xy 86.705764 53.75) (xy 87.241473 53.894236) (xy 87.301 53.6) (xy 87.241473 53.305764)
+				(xy 91.094236 80.15) (xy 91.094236 79.85) (xy 90.558527 79.705764) (xy 90.499 80) (xy 90.558527 80.294236)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 87.301 53.6) (xy 87.241473 53.894236) (xy 86.705764 53.75) (xy 86.705764 53.45) (xy 87.241473 53.305764)
+				(xy 90.570564 79.709005) (xy 90.60391 79.717983) (xy 91.085579 79.847669) (xy 91.092676 79.853128)
+				(xy 91.094236 79.858966) (xy 91.094236 80.141033) (xy 91.090809 80.149306) (xy 91.085578 80.152331)
+				(xy 90.570564 80.290994) (xy 90.561684 80.289836) (xy 90.556224 80.282738) (xy 90.556059 80.282039)
+				(xy 90.499469 80.002318) (xy 90.499469 79.99768) (xy 90.556055 79.71798) (xy 90.561054 79.710554)
+				(xy 90.569842 79.708835)
 			)
 		)
 	)
 	(zone
-		(net 1)
-		(net_name "+3V3")
+		(net 31)
+		(net_name "/MCU/SERVO_SIG")
 		(layer "F.Cu")
-		(uuid "c2743015-0214-4d44-8f0d-d0f52f42f865")
+		(uuid "b17697be-00c7-4f11-9625-a22fa57a0c15")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30027)
+		(priority 30055)
 		(attr
 			(teardrop
 				(type padvia)
@@ -48678,56 +48910,16 @@
 		)
 		(polygon
 			(pts
-				(xy 86.661799 119.394236) (xy 86.961799 119.394236) (xy 87.094236 118.858527) (xy 86.8 118.799)
-				(xy 86.505764 118.858527)
+				(xy 62.65 87.405764) (xy 62.35 87.405764) (xy 62.205764 87.941473) (xy 62.5 88.001) (xy 62.794236 87.941473)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 87.082268 118.856105) (xy 87.089696 118.861105) (xy 87.091415 118.869893) (xy 87.091305 118.870381)
-				(xy 86.963997 119.385344) (xy 86.958685 119.392553) (xy 86.952639 119.394236) (xy 86.670577 119.394236)
-				(xy 86.662304 119.390809) (xy 86.659344 119.385808) (xy 86.509322 118.870743) (xy 86.510298 118.861841)
-				(xy 86.517283 118.856238) (xy 86.518212 118.856008) (xy 86.797682 118.799469) (xy 86.802318 118.799469)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "c2a2ff4e-ccfe-42a9-9310-0cd120772c13")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30107)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 48.45 100.305765) (xy 48.150001 100.305764) (xy 48.005764 100.841473) (xy 48.3 100.900999) (xy 48.594236 100.841473)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 48.449306 100.309191) (xy 48.452331 100.314422) (xy 48.590994 100.829435) (xy 48.589836 100.838315)
-				(xy 48.582738 100.843775) (xy 48.582016 100.843945) (xy 48.30232 100.900529) (xy 48.29768 100.900529)
-				(xy 48.017983 100.843945) (xy 48.010554 100.838945) (xy 48.008835 100.830157) (xy 48.009005 100.829435)
-				(xy 48.14767 100.31442) (xy 48.153129 100.307324) (xy 48.158966 100.305764) (xy 48.441035 100.305764)
+				(xy 62.649306 87.409191) (xy 62.652331 87.414422) (xy 62.790994 87.929435) (xy 62.789836 87.938315)
+				(xy 62.782738 87.943775) (xy 62.782016 87.943945) (xy 62.50232 88.00053) (xy 62.49768 88.00053)
+				(xy 62.217983 87.943945) (xy 62.210554 87.938945) (xy 62.208835 87.930157) (xy 62.209005 87.929435)
+				(xy 62.347669 87.414422) (xy 62.353129 87.407324) (xy 62.358967 87.405764) (xy 62.641033 87.405764)
 			)
 		)
 	)
@@ -48735,10 +48927,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "c7443648-8ae2-4768-b965-6add5de550e0")
+		(uuid "b32442a6-3a38-421a-aa33-3686ffa4b1d5")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30144)
+		(priority 30130)
 		(attr
 			(teardrop
 				(type padvia)
@@ -48757,24 +48949,24 @@
 		)
 		(polygon
 			(pts
-				(xy 82.999999 134.0875) (xy 82.999999 134.3875) (xy 83.458527 134.294236) (xy 83.401 134) (xy 83.150559 133.833329)
+				(xy 84.87762 109.835103) (xy 84.87762 110.135103) (xy 85.005764 110.458527) (xy 85.301 110.4) (xy 85.466671 110.150559)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 83.401 134) (xy 83.458527 134.294236) (xy 82.999999 134.3875) (xy 82.999999 134.0875) (xy 83.150559 133.833329)
+				(xy 85.466671 110.150559) (xy 85.301 110.4) (xy 85.005764 110.458527) (xy 84.87762 110.135103) (xy 84.87762 109.835103)
 			)
 		)
 	)
 	(zone
-		(net 12)
-		(net_name "Net-(U2-SW)")
+		(net 85)
+		(net_name "/MCU/SPI2_SCK")
 		(layer "F.Cu")
-		(uuid "c76eef9f-55f1-4106-b8a7-6d082ef27b57")
+		(uuid "b349e9ac-72ca-46fe-8c2d-b115ab69349b")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30075)
+		(priority 30033)
 		(attr
 			(teardrop
 				(type padvia)
@@ -48793,16 +48985,394 @@
 		)
 		(polygon
 			(pts
-				(xy 82.85 50.894236) (xy 83.15 50.894236) (xy 83.294236 50.358527) (xy 83 50.299) (xy 82.705764 50.358527)
+				(xy 85.65 97.905764) (xy 85.35 97.905764) (xy 85.205764 98.441473) (xy 85.5 98.501) (xy 85.794236 98.441473)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 83.282017 50.356055) (xy 83.289445 50.361054) (xy 83.291164 50.369842) (xy 83.290994 50.370564)
-				(xy 83.152331 50.885578) (xy 83.146871 50.892676) (xy 83.141033 50.894236) (xy 82.858967 50.894236)
-				(xy 82.850694 50.890809) (xy 82.847669 50.885578) (xy 82.709005 50.370564) (xy 82.710163 50.361684)
-				(xy 82.717261 50.356224) (xy 82.717953 50.35606) (xy 82.997682 50.299469) (xy 83.002318 50.299469)
+				(xy 85.649306 97.909191) (xy 85.652331 97.914422) (xy 85.790994 98.429435) (xy 85.789836 98.438315)
+				(xy 85.782738 98.443775) (xy 85.782016 98.443945) (xy 85.50232 98.50053) (xy 85.49768 98.50053)
+				(xy 85.217983 98.443945) (xy 85.210554 98.438945) (xy 85.208835 98.430157) (xy 85.209005 98.429435)
+				(xy 85.347669 97.914422) (xy 85.353129 97.907324) (xy 85.358967 97.905764) (xy 85.641033 97.905764)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "b4cdbe99-ede8-4379-9bf9-d497626aeb88")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30062)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 80.3 55.755764) (xy 80 55.755764) (xy 79.855764 56.291473) (xy 80.15 56.351) (xy 80.444236 56.291473)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 80.299306 55.759191) (xy 80.302331 55.764422) (xy 80.440994 56.279435) (xy 80.439836 56.288315)
+				(xy 80.432738 56.293775) (xy 80.432016 56.293945) (xy 80.15232 56.35053) (xy 80.14768 56.35053)
+				(xy 79.867983 56.293945) (xy 79.860554 56.288945) (xy 79.858835 56.280157) (xy 79.859005 56.279435)
+				(xy 79.997669 55.764422) (xy 80.003129 55.757324) (xy 80.008967 55.755764) (xy 80.291033 55.755764)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "b5273d2f-2966-420f-b69e-be43fa4f7d45")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30119)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 83.55 55.75) (xy 83.25 55.75) (xy 83.105764 56.241473) (xy 83.4 56.301) (xy 83.694236 56.241473)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 83.694236 56.241473) (xy 83.4 56.301) (xy 83.105764 56.241473) (xy 83.25 55.75) (xy 83.55 55.75)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "b5370c07-ec08-495c-b136-e85e61bbaf39")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30127)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 52.158141 78.382131) (xy 52.158141 78.682131) (xy 52.350559 79.066671) (xy 52.601 78.9) (xy 52.766671 78.650559)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 52.174559 78.389373) (xy 52.753961 78.644952) (xy 52.760147 78.651427) (xy 52.759944 78.660379)
+				(xy 52.758985 78.66213) (xy 52.602303 78.898037) (xy 52.599039 78.901304) (xy 52.36158 79.059336)
+				(xy 52.352794 79.061067) (xy 52.345358 79.056078) (xy 52.344635 79.054832) (xy 52.159378 78.684603)
+				(xy 52.158141 78.679367) (xy 52.158141 78.400079) (xy 52.161568 78.391806) (xy 52.169841 78.388379)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "b54724c1-2e48-49a9-a8eb-addd50afff47")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30111)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 70.399066 112.131443) (xy 70.611198 112.343575) (xy 71.09199 112.066762) (xy 70.926026 111.816614)
+				(xy 70.675878 111.65065)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 70.926026 111.816614) (xy 71.09199 112.066762) (xy 70.611198 112.343575) (xy 70.399066 112.131443)
+				(xy 70.675878 111.65065)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "b73c1eed-bac4-4104-8a45-47166169a9a0")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30070)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 50.394236 113.419156) (xy 50.394236 113.119156) (xy 49.858527 113.005764) (xy 49.799 113.3)
+				(xy 49.858527 113.594236)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 50.394236 113.119156) (xy 50.394236 113.419156) (xy 49.858527 113.594236) (xy 49.799 113.3)
+				(xy 49.858527 113.005764)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "b902d98e-a801-44ec-9380-24f98dacaa86")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30017)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 82.325 147.75) (xy 82.325 148.25) (xy 82.841473 148.294236) (xy 82.901 148) (xy 82.841473 147.705764)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 82.901 148) (xy 82.841473 148.294236) (xy 82.325 148.25) (xy 82.325 147.75) (xy 82.841473 147.705764)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "bbf43d33-2f85-4ec7-a54f-4da4287f483e")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30059)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 72.116726 68.005764) (xy 71.816726 68.005764) (xy 71.705764 68.541473) (xy 72 68.601) (xy 72.294236 68.541473)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 72.294236 68.541473) (xy 72 68.601) (xy 71.705764 68.541473) (xy 71.816726 68.005764) (xy 72.116726 68.005764)
+			)
+		)
+	)
+	(zone
+		(net 31)
+		(net_name "/MCU/SERVO_SIG")
+		(layer "F.Cu")
+		(uuid "bcc5f314-1266-4cdb-927f-14b7f465c6c9")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30037)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 72.405764 75.35) (xy 72.405764 75.65) (xy 72.941473 75.794236) (xy 73.001 75.5) (xy 72.941473 75.205764)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 72.938315 75.210163) (xy 72.943775 75.217261) (xy 72.943945 75.217983) (xy 73.00053 75.49768)
+				(xy 73.00053 75.50232) (xy 72.943945 75.782016) (xy 72.938945 75.789445) (xy 72.930157 75.791164)
+				(xy 72.929435 75.790994) (xy 72.414422 75.652331) (xy 72.407324 75.646871) (xy 72.405764 75.641033)
+				(xy 72.405764 75.358966) (xy 72.409191 75.350693) (xy 72.414419 75.347669) (xy 72.929435 75.209005)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "bfcecbd6-69ac-4d04-8c31-e6b776687ae4")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30142)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 86.3848 73.550001) (xy 86.6848 73.550001) (xy 86.794236 73.158527) (xy 86.5 73.099) (xy 86.250559 73.266671)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 86.504789 73.099969) (xy 86.781899 73.156031) (xy 86.789328 73.161031) (xy 86.791047 73.169819)
+				(xy 86.790847 73.170649) (xy 86.68719 73.541451) (xy 86.681662 73.548496) (xy 86.675922 73.550001)
+				(xy 86.392203 73.550001) (xy 86.38393 73.546574) (xy 86.38163 73.543311) (xy 86.254871 73.275772)
+				(xy 86.254425 73.266828) (xy 86.258915 73.261053) (xy 86.495943 73.101726) (xy 86.50472 73.099956)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "c2a094cc-4dda-4a63-98b7-8e25ad0e5fdf")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30141)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 61.766216 132.310293) (xy 61.466216 132.310293) (xy 61.133329 132.450559) (xy 61.3 132.701)
+				(xy 61.594236 132.758527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 61.594236 132.758527) (xy 61.3 132.701) (xy 61.133329 132.450559) (xy 61.466216 132.310293)
+				(xy 61.766216 132.310293)
 			)
 		)
 	)
@@ -48895,10 +49465,10 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "c9f3382a-2680-41cf-b3f0-e63974f8c290")
+		(uuid "c779e76e-7234-4ca5-a135-07f91979ef09")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30090)
+		(priority 30016)
 		(attr
 			(teardrop
 				(type padvia)
@@ -48917,17 +49487,17 @@
 		)
 		(polygon
 			(pts
-				(xy 70.626254 133.585878) (xy 70.414122 133.373746) (xy 69.933329 133.650559) (xy 70.099293 133.900707)
-				(xy 70.349441 134.066671)
+				(xy 84.386051 107.754324) (xy 84.739604 107.40077) (xy 84.392081 106.990689) (xy 84.141933 107.156653)
+				(xy 83.975969 107.406801)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 70.420462 133.380086) (xy 70.619913 133.579537) (xy 70.62334 133.58781) (xy 70.62178 133.593648)
-				(xy 70.35566 134.055867) (xy 70.348562 134.061327) (xy 70.339682 134.060169) (xy 70.339052 134.059778)
-				(xy 70.101265 133.902015) (xy 70.097984 133.898734) (xy 69.940221 133.660947) (xy 69.938502 133.652159)
-				(xy 69.943502 133.64473) (xy 69.944132 133.644339) (xy 70.406353 133.378218) (xy 70.415231 133.377061)
+				(xy 84.398806 106.998625) (xy 84.732638 107.392551) (xy 84.735372 107.401078) (xy 84.731985 107.408388)
+				(xy 84.393669 107.746705) (xy 84.385396 107.750132) (xy 84.377832 107.747358) (xy 83.983905 107.413526)
+				(xy 83.979809 107.405563) (xy 83.981719 107.398133) (xy 84.140625 107.158623) (xy 84.143903 107.155345)
+				(xy 84.383413 106.996439) (xy 84.3922 106.994721)
 			)
 		)
 	)
@@ -48935,10 +49505,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "cc6bb738-3805-4c7f-93fc-29c57ad18c60")
+		(uuid "c7848037-a9d9-49d8-be81-a9a6227c3949")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30069)
+		(priority 30054)
 		(attr
 			(teardrop
 				(type padvia)
@@ -48957,13 +49527,13 @@
 		)
 		(polygon
 			(pts
-				(xy 81.694236 137.4125) (xy 81.694236 137.1125) (xy 81.158527 137.005764) (xy 81.099 137.3) (xy 81.158527 137.594236)
+				(xy 83.65 119.105764) (xy 83.35 119.105764) (xy 83.205764 119.641473) (xy 83.5 119.701) (xy 83.794236 119.641473)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 81.694236 137.1125) (xy 81.694236 137.4125) (xy 81.158527 137.594236) (xy 81.099 137.3) (xy 81.158527 137.005764)
+				(xy 83.794236 119.641473) (xy 83.5 119.701) (xy 83.205764 119.641473) (xy 83.35 119.105764) (xy 83.65 119.105764)
 			)
 		)
 	)
@@ -48971,10 +49541,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "ced54fb1-c8f9-4935-8b9c-4da71e62530b")
+		(uuid "c8f69bd3-89a2-471b-b36d-1e8236772adc")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30013)
+		(priority 30095)
 		(attr
 			(teardrop
 				(type padvia)
@@ -48993,26 +49563,26 @@
 		)
 		(polygon
 			(pts
-				(xy 86.156589 108.803036) (xy 85.803036 109.156589) (xy 86.150559 109.566671) (xy 86.400707 109.400707)
-				(xy 86.566671 109.150559)
+				(xy 82.39829 106.328047) (xy 82.610422 106.115915) (xy 82.333609 105.635122) (xy 82.083461 105.801086)
+				(xy 81.917497 106.051234)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 86.566671 109.150559) (xy 86.400707 109.400707) (xy 86.150559 109.566671) (xy 85.803036 109.156589)
-				(xy 86.156589 108.803036)
+				(xy 82.610422 106.115915) (xy 82.39829 106.328047) (xy 81.917497 106.051234) (xy 82.083461 105.801086)
+				(xy 82.333609 105.635122)
 			)
 		)
 	)
 	(zone
-		(net 3)
-		(net_name "GND")
+		(net 1)
+		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "d02b81e4-bbc3-4ea6-a213-9f2494cb909e")
+		(uuid "c9462766-2409-4cb8-a2be-7266178e542c")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30052)
+		(priority 30143)
 		(attr
 			(teardrop
 				(type padvia)
@@ -49031,13 +49601,16 @@
 		)
 		(polygon
 			(pts
-				(xy 96.9 63.094236) (xy 97.2 63.094236) (xy 97.394236 62.558527) (xy 97.1 62.499) (xy 96.805764 62.558527)
+				(xy 81.8848 73.550001) (xy 82.1848 73.550001) (xy 82.294236 73.158527) (xy 82 73.099) (xy 81.750559 73.266671)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 97.394236 62.558527) (xy 97.2 63.094236) (xy 96.9 63.094236) (xy 96.805764 62.558527) (xy 97.1 62.499)
+				(xy 82.004789 73.099969) (xy 82.281899 73.156031) (xy 82.289328 73.161031) (xy 82.291047 73.169819)
+				(xy 82.290847 73.170649) (xy 82.18719 73.541451) (xy 82.181662 73.548496) (xy 82.175922 73.550001)
+				(xy 81.892203 73.550001) (xy 81.88393 73.546574) (xy 81.88163 73.543311) (xy 81.754871 73.275772)
+				(xy 81.754425 73.266828) (xy 81.758915 73.261053) (xy 81.995943 73.101726) (xy 82.00472 73.099956)
 			)
 		)
 	)
@@ -49045,10 +49618,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "d338fba0-a889-43d9-9ffc-1296b382671c")
+		(uuid "c98e97da-abb2-4152-a5a8-f95fbccaed67")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30017)
+		(priority 30108)
 		(attr
 			(teardrop
 				(type padvia)
@@ -49067,13 +49640,94 @@
 		)
 		(polygon
 			(pts
-				(xy 82.325 147.75) (xy 82.325 148.25) (xy 82.841473 148.294236) (xy 82.901 148) (xy 82.841473 147.705764)
+				(xy 74.833167 96.10079) (xy 74.621035 95.888658) (xy 74.140243 96.165471) (xy 74.306207 96.415619)
+				(xy 74.556355 96.581583)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 82.901 148) (xy 82.841473 148.294236) (xy 82.325 148.25) (xy 82.325 147.75) (xy 82.841473 147.705764)
+				(xy 74.833167 96.10079) (xy 74.556355 96.581583) (xy 74.306207 96.415619) (xy 74.140243 96.165471)
+				(xy 74.621035 95.888658)
+			)
+		)
+	)
+	(zone
+		(net 55)
+		(net_name "/Flash/IO3")
+		(layer "F.Cu")
+		(uuid "ccbb181f-353f-4a99-be00-f55b146f1024")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30114)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 62.47129 127.740842) (xy 62.259158 127.52871) (xy 61.833329 127.852533) (xy 61.999293 128.102681)
+				(xy 62.249441 128.268645)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 62.266381 127.535933) (xy 62.46573 127.735282) (xy 62.469157 127.743555) (xy 62.468243 127.748089)
+				(xy 62.254917 128.255616) (xy 62.248552 128.261915) (xy 62.239597 128.261868) (xy 62.237663 128.260831)
+				(xy 62.001265 128.103989) (xy 61.997984 128.100708) (xy 61.839393 127.861673) (xy 61.837674 127.852885)
+				(xy 61.842058 127.845894) (xy 62.251028 127.534892) (xy 62.259686 127.532613)
+			)
+		)
+	)
+	(zone
+		(net 57)
+		(net_name "/MCU/SERVO_EN")
+		(layer "F.Cu")
+		(uuid "cd6a4147-851b-424d-b301-3c179391ed61")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30117)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 91.75 63.65) (xy 91.75 63.35) (xy 91.258527 63.205764) (xy 91.199 63.5) (xy 91.258527 63.794236)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 91.270752 63.209351) (xy 91.741595 63.347533) (xy 91.748568 63.353151) (xy 91.75 63.35876) (xy 91.75 63.641239)
+				(xy 91.746573 63.649512) (xy 91.741595 63.652466) (xy 91.270761 63.790645) (xy 91.261857 63.789686)
+				(xy 91.256239 63.782713) (xy 91.256 63.781749) (xy 91.199469 63.502318) (xy 91.199469 63.49768)
+				(xy 91.228709 63.353151) (xy 91.255999 63.218259) (xy 91.260998 63.210832) (xy 91.269786 63.209113)
 			)
 		)
 	)
@@ -49081,7 +49735,120 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "d3427142-9dbe-4be6-838e-db75f2ddded0")
+		(uuid "cef84176-3b70-4845-a3d1-7e8c0a965c1b")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30115)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 83.609848 107.119542) (xy 83.397717 107.331673) (xy 83.405764 107.821338) (xy 83.700707 107.763518)
+				(xy 83.949441 107.59614)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 83.949441 107.59614) (xy 83.700707 107.763518) (xy 83.405764 107.821338) (xy 83.397717 107.331673)
+				(xy 83.609848 107.119542)
+			)
+		)
+	)
+	(zone
+		(net 12)
+		(net_name "Net-(U2-SW)")
+		(layer "F.Cu")
+		(uuid "d0863b6d-40d0-4210-93e7-cb8111e6ee80")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30041)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 86.705764 53.45) (xy 86.705764 53.75) (xy 87.241473 53.894236) (xy 87.301 53.6) (xy 87.241473 53.305764)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 87.301 53.6) (xy 87.241473 53.894236) (xy 86.705764 53.75) (xy 86.705764 53.45) (xy 87.241473 53.305764)
+			)
+		)
+	)
+	(zone
+		(net 57)
+		(net_name "/MCU/SERVO_EN")
+		(layer "F.Cu")
+		(uuid "d5029e85-8e76-47b3-95fb-56cd1a6fd32b")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30065)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 71.405764 74.35) (xy 71.405764 74.65) (xy 71.941473 74.794236) (xy 72.001 74.5) (xy 71.941473 74.205764)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 71.938315 74.210163) (xy 71.943775 74.217261) (xy 71.943945 74.217983) (xy 72.00053 74.49768)
+				(xy 72.00053 74.50232) (xy 71.943945 74.782016) (xy 71.938945 74.789445) (xy 71.930157 74.791164)
+				(xy 71.929435 74.790994) (xy 71.414422 74.652331) (xy 71.407324 74.646871) (xy 71.405764 74.641033)
+				(xy 71.405764 74.358966) (xy 71.409191 74.350693) (xy 71.414419 74.347669) (xy 71.929435 74.209005)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "d78bc936-4a63-4afd-864d-308f170bc815")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30000)
@@ -49116,13 +49883,13 @@
 		)
 	)
 	(zone
-		(net 3)
-		(net_name "GND")
+		(net 59)
+		(net_name "/MCU/BUZZER")
 		(layer "F.Cu")
-		(uuid "d3814873-b1a6-4dba-81e9-aee445472c8a")
+		(uuid "d9293b51-0404-490b-864a-bc810405bc75")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30093)
+		(priority 30084)
 		(attr
 			(teardrop
 				(type padvia)
@@ -49141,127 +49908,18 @@
 		)
 		(polygon
 			(pts
-				(xy 72.185878 134.173746) (xy 71.973746 134.385878) (xy 72.250559 134.866671) (xy 72.500707 134.700707)
-				(xy 72.666671 134.450559)
+				(xy 69.685879 105.923494) (xy 69.473746 106.135626) (xy 69.750559 106.616419) (xy 70.000707 106.450455)
+				(xy 70.166671 106.200307)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 72.666671 134.450559) (xy 72.500707 134.700707) (xy 72.250559 134.866671) (xy 71.973746 134.385878)
-				(xy 72.185878 134.173746)
-			)
-		)
-	)
-	(zone
-		(net 31)
-		(net_name "/MCU/SERVO_SIG")
-		(layer "F.Cu")
-		(uuid "d80922bb-d3a8-408c-9ea5-726cc781e7a5")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30055)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 62.65 87.405764) (xy 62.35 87.405764) (xy 62.205764 87.941473) (xy 62.5 88.001) (xy 62.794236 87.941473)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 62.649306 87.409191) (xy 62.652331 87.414422) (xy 62.790994 87.929435) (xy 62.789836 87.938315)
-				(xy 62.782738 87.943775) (xy 62.782016 87.943945) (xy 62.50232 88.00053) (xy 62.49768 88.00053)
-				(xy 62.217983 87.943945) (xy 62.210554 87.938945) (xy 62.208835 87.930157) (xy 62.209005 87.929435)
-				(xy 62.347669 87.414422) (xy 62.353129 87.407324) (xy 62.358967 87.405764) (xy 62.641033 87.405764)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "d9baf712-ff1e-411d-94c0-8d591876f350")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30074)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 86.55 67.294236) (xy 86.85 67.294236) (xy 86.994236 66.758527) (xy 86.7 66.699) (xy 86.405764 66.758527)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 86.994236 66.758527) (xy 86.85 67.294236) (xy 86.55 67.294236) (xy 86.405764 66.758527) (xy 86.7 66.699)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "de427f9e-63b2-4de5-8c49-94ed259272ac")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30128)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 85.6 118.0882) (xy 85.9 118.0882) (xy 86.062779 117.624123) (xy 85.768543 117.564596) (xy 85.474307 117.624123)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 86.062779 117.624123) (xy 85.983937 117.848897) (xy 85.977531 117.858486) (xy 85.973544 117.878526)
-				(xy 85.9 118.0882) (xy 85.6 118.0882) (xy 85.474307 117.624123) (xy 85.768543 117.564596)
+				(xy 69.693647 105.927966) (xy 69.976438 106.090781) (xy 70.155867 106.194087) (xy 70.161327 106.201185)
+				(xy 70.160169 106.210065) (xy 70.159778 106.210695) (xy 70.002015 106.448482) (xy 69.998734 106.451763)
+				(xy 69.760947 106.609526) (xy 69.752159 106.611245) (xy 69.74473 106.606245) (xy 69.744339 106.605615)
+				(xy 69.516966 106.210695) (xy 69.478218 106.143394) (xy 69.477061 106.134516) (xy 69.480084 106.129287)
+				(xy 69.679539 105.929833) (xy 69.687811 105.926407)
 			)
 		)
 	)
@@ -49269,10 +49927,10 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "df219570-b8fd-40b2-acb9-4471b0cf6e43")
+		(uuid "db089a23-9f3e-47eb-8304-c04a1962d102")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30083)
+		(priority 30105)
 		(attr
 			(teardrop
 				(type padvia)
@@ -49291,17 +49949,17 @@
 		)
 		(polygon
 			(pts
-				(xy 69.610491 134.250868) (xy 69.822623 134.463) (xy 70.266671 134.149441) (xy 70.100707 133.899293)
-				(xy 69.850559 133.733329)
+				(xy 93.994235 85.149999) (xy 93.994236 84.85) (xy 93.458527 84.705763) (xy 93.399001 84.999999)
+				(xy 93.458527 85.294235)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 69.860364 133.739994) (xy 69.861906 133.740857) (xy 70.089166 133.891636) (xy 70.098734 133.897984)
-				(xy 70.102015 133.901265) (xy 70.260388 134.139971) (xy 70.262107 134.148759) (xy 70.257388 134.155996)
-				(xy 69.830675 134.457314) (xy 69.82194 134.459287) (xy 69.815653 134.45603) (xy 69.616271 134.256648)
-				(xy 69.612844 134.248375) (xy 69.613929 134.243456) (xy 69.844827 133.745684) (xy 69.851417 133.739622)
+				(xy 93.470566 84.709004) (xy 93.985578 84.847668) (xy 93.992675 84.853128) (xy 93.994235 84.858966)
+				(xy 93.994235 85.141032) (xy 93.990808 85.149305) (xy 93.985577 85.15233) (xy 93.470564 85.290993)
+				(xy 93.461684 85.289835) (xy 93.456224 85.282737) (xy 93.456059 85.282039) (xy 93.39947 85.002317)
+				(xy 93.39947 84.997679) (xy 93.456055 84.717979) (xy 93.461054 84.710553) (xy 93.469842 84.708834)
 			)
 		)
 	)
@@ -49309,10 +49967,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "df84d9d5-750c-479e-a44b-73b206e42e27")
+		(uuid "db5a4931-0378-4673-9602-ade11f919a40")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30138)
+		(priority 30118)
 		(attr
 			(teardrop
 				(type padvia)
@@ -49331,15 +49989,13 @@
 		)
 		(polygon
 			(pts
-				(xy 48.700624 108.850481) (xy 48.400624 108.850481) (xy 48.605764 109.358527) (xy 48.9 109.301)
-				(xy 49.066671 109.050559)
+				(xy 91.75 61.85) (xy 91.75 61.55) (xy 91.258527 61.405764) (xy 91.199 61.7) (xy 91.258527 61.994236)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 49.066671 109.050559) (xy 48.9 109.301) (xy 48.605764 109.358527) (xy 48.400624 108.850481)
-				(xy 48.700624 108.850481)
+				(xy 91.75 61.55) (xy 91.75 61.85) (xy 91.258527 61.994236) (xy 91.199 61.7) (xy 91.258527 61.405764)
 			)
 		)
 	)
@@ -49347,10 +50003,10 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "e15556d0-9445-41d4-a73b-f4b7311a2f44")
+		(uuid "dc35961a-5c57-4b76-9a2a-335da50ab45f")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30011)
+		(priority 30035)
 		(attr
 			(teardrop
 				(type padvia)
@@ -49369,56 +50025,17 @@
 		)
 		(polygon
 			(pts
-				(xy 95.405764 137.75) (xy 95.405764 138.25) (xy 95.941473 138.294236) (xy 96.001 138) (xy 95.941473 137.705764)
+				(xy 90.894236 69.375) (xy 90.894236 69.075) (xy 90.358527 68.905764) (xy 90.299 69.2) (xy 90.358527 69.494236)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 95.939631 137.709354) (xy 95.943535 137.71596) (xy 96.00053 137.99768) (xy 96.00053 138.00232)
-				(xy 95.943535 138.284039) (xy 95.938535 138.291468) (xy 95.931104 138.293379) (xy 95.416501 138.250886)
-				(xy 95.408538 138.24679) (xy 95.405764 138.239226) (xy 95.405764 137.760773) (xy 95.409191 137.7525)
-				(xy 95.416499 137.749113) (xy 95.931104 137.70662)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "e1bb50b0-e4f8-443d-ae45-b2368d081aa6")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30089)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 66.683619 128.823995) (xy 66.895751 129.036127) (xy 67.376544 128.759314) (xy 67.21058 128.509166)
-				(xy 66.960432 128.343202)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 66.97019 128.349703) (xy 66.97082 128.350094) (xy 67.208607 128.507857) (xy 67.211888 128.511138)
-				(xy 67.369651 128.748925) (xy 67.37137 128.757713) (xy 67.36637 128.765142) (xy 67.36574 128.765533)
-				(xy 66.903521 129.031653) (xy 66.894641 129.032811) (xy 66.88941 129.029786) (xy 66.689959 128.830335)
-				(xy 66.686532 128.822062) (xy 66.688091 128.816227) (xy 66.954212 128.354004) (xy 66.96131 128.348545)
+				(xy 90.370929 68.909681) (xy 90.88606 69.072417) (xy 90.892917 69.078177) (xy 90.894236 69.083574)
+				(xy 90.894236 69.365617) (xy 90.890809 69.37389) (xy 90.885078 69.377038) (xy 90.370171 69.491644)
+				(xy 90.361351 69.490096) (xy 90.356208 69.482765) (xy 90.356161 69.482543) (xy 90.334816 69.377038)
+				(xy 90.299469 69.202318) (xy 90.299469 69.19768) (xy 90.322554 69.083574) (xy 90.355946 68.918518)
+				(xy 90.360945 68.911092) (xy 90.369733 68.909373)
 			)
 		)
 	)
@@ -49426,7 +50043,7 @@
 		(net 112)
 		(net_name "/MCU/BARO_INT")
 		(layer "F.Cu")
-		(uuid "e1ecbe46-f5ea-4586-a202-003989d9052b")
+		(uuid "dca17c66-5d82-4030-9a08-ae6b7636541c")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30104)
@@ -49463,13 +50080,13 @@
 		)
 	)
 	(zone
-		(net 3)
-		(net_name "GND")
+		(net 1)
+		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "e411f95a-4d87-44c6-adc7-ff6d0cb10f4b")
+		(uuid "df989df0-cc71-4511-af83-e9053b81d327")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30048)
+		(priority 30040)
 		(attr
 			(teardrop
 				(type padvia)
@@ -49488,13 +50105,94 @@
 		)
 		(polygon
 			(pts
-				(xy 75.05 67.705764) (xy 74.75 67.705764) (xy 74.605764 68.241473) (xy 74.9 68.301) (xy 75.194236 68.241473)
+				(xy 89.705764 69.05) (xy 89.705764 69.35) (xy 90.241473 69.494236) (xy 90.301 69.2) (xy 90.241473 68.905764)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 75.194236 68.241473) (xy 74.9 68.301) (xy 74.605764 68.241473) (xy 74.75 67.705764) (xy 75.05 67.705764)
+				(xy 90.238315 68.910163) (xy 90.243775 68.917261) (xy 90.243945 68.917983) (xy 90.30053 69.19768)
+				(xy 90.30053 69.20232) (xy 90.243945 69.482016) (xy 90.238945 69.489445) (xy 90.230157 69.491164)
+				(xy 90.229435 69.490994) (xy 89.714422 69.352331) (xy 89.707324 69.346871) (xy 89.705764 69.341033)
+				(xy 89.705764 69.058966) (xy 89.709191 69.050693) (xy 89.714419 69.047669) (xy 90.229435 68.909005)
+			)
+		)
+	)
+	(zone
+		(net 102)
+		(net_name "/MCU/SPI2_NSS")
+		(layer "F.Cu")
+		(uuid "e006ec7e-b7a0-4eb4-8819-de2171f2deb2")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30028)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 84.65 98.405764) (xy 84.35 98.405764) (xy 84.205764 98.941473) (xy 84.5 99.001) (xy 84.794236 98.941473)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 84.649306 98.409191) (xy 84.652331 98.414422) (xy 84.790994 98.929435) (xy 84.789836 98.938315)
+				(xy 84.782738 98.943775) (xy 84.782016 98.943945) (xy 84.50232 99.00053) (xy 84.49768 99.00053)
+				(xy 84.217983 98.943945) (xy 84.210554 98.938945) (xy 84.208835 98.930157) (xy 84.209005 98.929435)
+				(xy 84.347669 98.414422) (xy 84.353129 98.407324) (xy 84.358967 98.405764) (xy 84.641033 98.405764)
+			)
+		)
+	)
+	(zone
+		(net 31)
+		(net_name "/MCU/SERVO_SIG")
+		(layer "F.Cu")
+		(uuid "e06f30e9-feeb-4ab7-9462-71244243f3e9")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30058)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 62.35 97.094236) (xy 62.65 97.094236) (xy 62.794236 96.558527) (xy 62.5 96.499) (xy 62.205764 96.558527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 62.782017 96.556055) (xy 62.789445 96.561054) (xy 62.791164 96.569842) (xy 62.790994 96.570564)
+				(xy 62.652331 97.085578) (xy 62.646871 97.092676) (xy 62.641033 97.094236) (xy 62.358967 97.094236)
+				(xy 62.350694 97.090809) (xy 62.347669 97.085578) (xy 62.209005 96.570564) (xy 62.210163 96.561684)
+				(xy 62.217261 96.556224) (xy 62.217953 96.55606) (xy 62.497682 96.499469) (xy 62.502318 96.499469)
 			)
 		)
 	)
@@ -49502,10 +50200,10 @@
 		(net 1)
 		(net_name "+3V3")
 		(layer "F.Cu")
-		(uuid "e47ba1b9-b4af-44f0-8966-638e4e8ff7b4")
+		(uuid "e37f3465-d4d6-4522-bc7c-7168bd8dc3c2")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30042)
+		(priority 30140)
 		(attr
 			(teardrop
 				(type padvia)
@@ -49524,134 +50222,18 @@
 		)
 		(polygon
 			(pts
-				(xy 81.925 55.730764) (xy 81.625 55.730764) (xy 81.480764 56.266473) (xy 81.775 56.326) (xy 82.069236 56.266473)
+				(xy 83.134036 135.840594) (xy 82.921905 135.628463) (xy 82.805764 136.241473) (xy 83.099293 136.300707)
+				(xy 83.349441 136.133329)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 81.924306 55.734191) (xy 81.927331 55.739422) (xy 82.065994 56.254435) (xy 82.064836 56.263315)
-				(xy 82.057738 56.268775) (xy 82.057016 56.268945) (xy 81.77732 56.32553) (xy 81.77268 56.32553)
-				(xy 81.492983 56.268945) (xy 81.485554 56.263945) (xy 81.483835 56.255157) (xy 81.484005 56.254435)
-				(xy 81.622669 55.739422) (xy 81.628129 55.732324) (xy 81.633967 55.730764) (xy 81.916033 55.730764)
-			)
-		)
-	)
-	(zone
-		(net 13)
-		(net_name "/MCU/BATT_VSENSE")
-		(layer "F.Cu")
-		(uuid "e5049205-28f4-403d-964b-cb8296196831")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30067)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 93.394236 76.55) (xy 93.394236 76.25) (xy 92.858527 76.105764) (xy 92.799 76.4) (xy 92.858527 76.694236)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 92.870564 76.109005) (xy 92.90391 76.117983) (xy 93.385579 76.247669) (xy 93.392676 76.253128)
-				(xy 93.394236 76.258966) (xy 93.394236 76.541033) (xy 93.390809 76.549306) (xy 93.385578 76.552331)
-				(xy 92.870564 76.690994) (xy 92.861684 76.689836) (xy 92.856224 76.682738) (xy 92.856059 76.682039)
-				(xy 92.799469 76.402318) (xy 92.799469 76.39768) (xy 92.856055 76.11798) (xy 92.861054 76.110554)
-				(xy 92.869842 76.108835)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "e607260d-0434-4b8b-864e-8f129364a6f5")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30137)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 60.160624 72.672568) (xy 60.160624 72.372568) (xy 59.949441 72.033329) (xy 59.699 72.2) (xy 59.641473 72.494236)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 59.955622 72.043269) (xy 59.955815 72.043568) (xy 60.158857 72.369729) (xy 60.160624 72.375912)
-				(xy 60.160624 72.656178) (xy 60.157197 72.664451) (xy 60.148924 72.667878) (xy 60.145123 72.667243)
-				(xy 59.65111 72.497546) (xy 59.644399 72.491618) (xy 59.643428 72.484236) (xy 59.664607 72.375912)
-				(xy 59.698063 72.204788) (xy 59.703013 72.197329) (xy 59.9394 72.04001) (xy 59.948186 72.03828)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "e624ec56-d6eb-4be7-9330-d980d15f3e68")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30127)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 52.158141 78.382131) (xy 52.158141 78.682131) (xy 52.350559 79.066671) (xy 52.601 78.9) (xy 52.766671 78.650559)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 52.174559 78.389373) (xy 52.753961 78.644952) (xy 52.760147 78.651427) (xy 52.759944 78.660379)
-				(xy 52.758985 78.66213) (xy 52.602303 78.898037) (xy 52.599039 78.901304) (xy 52.36158 79.059336)
-				(xy 52.352794 79.061067) (xy 52.345358 79.056078) (xy 52.344635 79.054832) (xy 52.159378 78.684603)
-				(xy 52.158141 78.679367) (xy 52.158141 78.400079) (xy 52.161568 78.391806) (xy 52.169841 78.388379)
+				(xy 82.937554 135.644112) (xy 83.133408 135.839966) (xy 83.134559 135.841305) (xy 83.34219 136.123475)
+				(xy 83.344333 136.132169) (xy 83.3397 136.139833) (xy 83.339272 136.140133) (xy 83.10334 136.297998)
+				(xy 83.094559 136.299751) (xy 83.09452 136.299743) (xy 82.817098 136.24376) (xy 82.809666 136.238764)
+				(xy 82.807916 136.230113) (xy 82.824964 136.140133) (xy 82.917785 135.650206) (xy 82.922692 135.642716)
+				(xy 82.931459 135.640889)
 			)
 		)
 	)
@@ -49659,10 +50241,10 @@
 		(net 3)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "e90330d6-b890-4958-88e7-69e33040177d")
+		(uuid "e69638e4-d4a6-48f7-893d-e20a385fe213")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30119)
+		(priority 30121)
 		(attr
 			(teardrop
 				(type padvia)
@@ -49681,24 +50263,24 @@
 		)
 		(polygon
 			(pts
-				(xy 83.55 55.75) (xy 83.25 55.75) (xy 83.105764 56.241473) (xy 83.4 56.301) (xy 83.694236 56.241473)
+				(xy 82.65 135.7625) (xy 82.35 135.7625) (xy 82.100556 136.133329) (xy 82.349997 136.301) (xy 82.644233 136.358527)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 83.694236 56.241473) (xy 83.4 56.301) (xy 83.105764 56.241473) (xy 83.25 55.75) (xy 83.55 55.75)
+				(xy 82.644233 136.358527) (xy 82.349997 136.301) (xy 82.100556 136.133329) (xy 82.35 135.7625) (xy 82.65 135.7625)
 			)
 		)
 	)
 	(zone
-		(net 85)
-		(net_name "/MCU/SPI2_SCK")
+		(net 3)
+		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "e94defdb-0510-451b-91df-59dc594eaf85")
+		(uuid "e79ca757-5641-4a87-92e7-03e8d94f3680")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30102)
+		(priority 30091)
 		(attr
 			(teardrop
 				(type padvia)
@@ -49717,17 +50299,15 @@
 		)
 		(polygon
 			(pts
-				(xy 86.473746 100.314122) (xy 86.685878 100.526254) (xy 87.166671 100.249441) (xy 87.000707 99.999293)
-				(xy 86.750559 99.833329)
+				(xy 78.414122 67.726254) (xy 78.626254 67.514122) (xy 78.349441 67.033329) (xy 78.099293 67.199293)
+				(xy 77.933329 67.449441)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 86.760317 99.83983) (xy 86.760947 99.840221) (xy 86.998734 99.997984) (xy 87.002015 100.001265)
-				(xy 87.159778 100.239052) (xy 87.161497 100.24784) (xy 87.156497 100.255269) (xy 87.155867 100.25566)
-				(xy 86.693648 100.52178) (xy 86.684768 100.522938) (xy 86.679537 100.519913) (xy 86.480086 100.320462)
-				(xy 86.476659 100.312189) (xy 86.478218 100.306354) (xy 86.744339 99.844131) (xy 86.751437 99.838672)
+				(xy 78.626254 67.514122) (xy 78.414122 67.726254) (xy 77.933329 67.449441) (xy 78.099293 67.199293)
+				(xy 78.349441 67.033329)
 			)
 		)
 	)
@@ -49780,13 +50360,13 @@
 		)
 	)
 	(zone
-		(net 1)
-		(net_name "+3V3")
+		(net 116)
+		(net_name "/MCU/SPI1_SCK")
 		(layer "F.Cu")
-		(uuid "ed6106a4-b557-42b3-9748-59e2472c61f6")
+		(uuid "ee130c3f-04e9-4a2d-aa2f-d833eeac6b8f")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30142)
+		(priority 30072)
 		(attr
 			(teardrop
 				(type padvia)
@@ -49805,425 +50385,27 @@
 		)
 		(polygon
 			(pts
-				(xy 86.3848 73.550001) (xy 86.6848 73.550001) (xy 86.794236 73.158527) (xy 86.5 73.099) (xy 86.250559 73.266671)
+				(xy 77.65 119.905764) (xy 77.35 119.905764) (xy 77.205764 120.441473) (xy 77.5 120.501) (xy 77.794236 120.441473)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 86.504789 73.099969) (xy 86.781899 73.156031) (xy 86.789328 73.161031) (xy 86.791047 73.169819)
-				(xy 86.790847 73.170649) (xy 86.68719 73.541451) (xy 86.681662 73.548496) (xy 86.675922 73.550001)
-				(xy 86.392203 73.550001) (xy 86.38393 73.546574) (xy 86.38163 73.543311) (xy 86.254871 73.275772)
-				(xy 86.254425 73.266828) (xy 86.258915 73.261053) (xy 86.495943 73.101726) (xy 86.50472 73.099956)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "ef0b2038-ef05-4575-bac8-631c7b01973c")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30018)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 86.900001 118.205764) (xy 86.600001 118.205764) (xy 86.505764 118.741473) (xy 86.8 118.801)
-				(xy 87.094236 118.741473)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 86.900071 118.209191) (xy 86.902797 118.213476) (xy 87.089608 118.728709) (xy 87.089207 118.737655)
-				(xy 87.082597 118.743696) (xy 87.080929 118.744165) (xy 86.80232 118.80053) (xy 86.79768 118.80053)
-				(xy 86.516943 118.743734) (xy 86.509514 118.738734) (xy 86.50774 118.730239) (xy 86.598299 118.215437)
-				(xy 86.603107 118.207883) (xy 86.609822 118.205764) (xy 86.891798 118.205764)
-			)
-		)
-	)
-	(zone
-		(net 75)
-		(net_name "/MCU/IMU_INT2")
-		(layer "F.Cu")
-		(uuid "f80323c9-ce77-47a6-b473-6b0491f3e683")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30099)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 91.435878 81.723747) (xy 91.223746 81.935879) (xy 91.500559 82.416672) (xy 91.750707 82.250708)
-				(xy 91.916671 82.00056)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 91.443646 81.728219) (xy 91.728798 81.892393) (xy 91.905867 81.99434) (xy 91.911327 82.001438)
-				(xy 91.910169 82.010318) (xy 91.909778 82.010948) (xy 91.752015 82.248735) (xy 91.748734 82.252016)
-				(xy 91.510947 82.409779) (xy 91.502159 82.411498) (xy 91.49473 82.406498) (xy 91.494339 82.405868)
-				(xy 91.266966 82.010948) (xy 91.228218 81.943647) (xy 91.227061 81.934769) (xy 91.230084 81.92954)
-				(xy 91.429538 81.730086) (xy 91.43781 81.72666)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "fa72a9be-b01c-4a66-a4fe-d42ee084af9c")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30141)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 61.766216 132.310293) (xy 61.466216 132.310293) (xy 61.133329 132.450559) (xy 61.3 132.701)
-				(xy 61.594236 132.758527)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 61.594236 132.758527) (xy 61.3 132.701) (xy 61.133329 132.450559) (xy 61.466216 132.310293)
-				(xy 61.766216 132.310293)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "+3V3")
-		(layer "F.Cu")
-		(uuid "ff5296b4-d846-4484-a687-bd6bfdec746a")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30105)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 93.994235 85.149999) (xy 93.994236 84.85) (xy 93.458527 84.705763) (xy 93.399001 84.999999)
-				(xy 93.458527 85.294235)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 93.470566 84.709004) (xy 93.985578 84.847668) (xy 93.992675 84.853128) (xy 93.994235 84.858966)
-				(xy 93.994235 85.141032) (xy 93.990808 85.149305) (xy 93.985577 85.15233) (xy 93.470564 85.290993)
-				(xy 93.461684 85.289835) (xy 93.456224 85.282737) (xy 93.456059 85.282039) (xy 93.39947 85.002317)
-				(xy 93.39947 84.997679) (xy 93.456055 84.717979) (xy 93.461054 84.710553) (xy 93.469842 84.708834)
-			)
-		)
-	)
-	(zone
-		(net 49)
-		(net_name "/MCU/BOOT0")
-		(layer "F.Cu")
-		(uuid "ff9b8a7d-34f1-4770-8174-1c96ae15293a")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30077)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 61.905764 104.15) (xy 61.905764 104.45) (xy 62.441473 104.594236) (xy 62.501 104.3) (xy 62.441473 104.005764)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 62.438315 104.010163) (xy 62.443775 104.017261) (xy 62.443945 104.017983) (xy 62.50053 104.29768)
-				(xy 62.50053 104.30232) (xy 62.443945 104.582016) (xy 62.438945 104.589445) (xy 62.430157 104.591164)
-				(xy 62.429435 104.590994) (xy 61.914422 104.452331) (xy 61.907324 104.446871) (xy 61.905764 104.441033)
-				(xy 61.905764 104.158966) (xy 61.909191 104.150693) (xy 61.914419 104.147669) (xy 62.429435 104.009005)
-			)
-		)
-	)
-	(zone
-		(net 85)
-		(net_name "/MCU/SPI2_SCK")
-		(layer "B.Cu")
-		(uuid "021010fd-12f3-42dc-ac98-d5fe26decf09")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30039)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 86.685878 99.473746) (xy 86.473746 99.685878) (xy 86.750559 100.166671) (xy 87.000707 100.000707)
-				(xy 87.166671 99.750559)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 86.693646 99.478218) (xy 86.978798 99.642392) (xy 87.155867 99.744339) (xy 87.161327 99.751437)
-				(xy 87.160169 99.760317) (xy 87.159778 99.760947) (xy 87.002015 99.998734) (xy 86.998734 100.002015)
-				(xy 86.760947 100.159778) (xy 86.752159 100.161497) (xy 86.74473 100.156497) (xy 86.744339 100.155867)
-				(xy 86.516966 99.760947) (xy 86.478218 99.693646) (xy 86.477061 99.684768) (xy 86.480084 99.679539)
-				(xy 86.679538 99.480085) (xy 86.68781 99.476659)
-			)
-		)
-	)
-	(zone
-		(net 112)
-		(net_name "/MCU/BARO_INT")
-		(layer "B.Cu")
-		(uuid "0400ee68-6fda-405b-a8f5-5655c01b71d6")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30032)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 77.485878 136.273746) (xy 77.273746 136.485878) (xy 77.550559 136.966671) (xy 77.800707 136.800707)
-				(xy 77.966671 136.550559)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 77.493646 136.278218) (xy 77.778798 136.442392) (xy 77.955867 136.544339) (xy 77.961327 136.551437)
-				(xy 77.960169 136.560317) (xy 77.959778 136.560947) (xy 77.802015 136.798734) (xy 77.798734 136.802015)
-				(xy 77.560947 136.959778) (xy 77.552159 136.961497) (xy 77.54473 136.956497) (xy 77.544339 136.955867)
-				(xy 77.316966 136.560947) (xy 77.278218 136.493646) (xy 77.277061 136.484768) (xy 77.280084 136.479539)
-				(xy 77.479538 136.280085) (xy 77.48781 136.276659)
-			)
-		)
-	)
-	(zone
-		(net 84)
-		(net_name "/MCU/SPI1_MOSI")
-		(layer "B.Cu")
-		(uuid "0a80e5e2-a9a7-4343-8194-09c6d86115b2")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30044)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 78.175214 113.887345) (xy 78.387345 113.675214) (xy 77.758527 113.455765) (xy 77.699293 113.749294)
-				(xy 77.758527 114.044237)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 77.771191 113.460184) (xy 78.369749 113.669073) (xy 78.37643 113.675034) (xy 78.37694 113.683974)
-				(xy 78.374166 113.688392) (xy 78.177001 113.885557) (xy 78.172851 113.888234) (xy 77.77141 114.039386)
-				(xy 77.76246 114.039094) (xy 77.756337 114.032559) (xy 77.755816 114.03074) (xy 77.699756 113.751599)
-				(xy 77.699757 113.746989) (xy 77.755872 113.468917) (xy 77.760868 113.461487) (xy 77.769655 113.459764)
-			)
-		)
-	)
-	(zone
-		(net 82)
-		(net_name "/MCU/SPI4_SCK")
-		(layer "B.Cu")
-		(uuid "13b81c18-d42c-4aea-a364-b5301c147aaa")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30043)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 86.27145 115.15) (xy 86.27145 115.45) (xy 86.450559 115.866671) (xy 86.701 115.7) (xy 86.866671 115.450559)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 86.288424 115.158571) (xy 86.854908 115.444619) (xy 86.860748 115.451407) (xy 86.860078 115.460337)
-				(xy 86.85938 115.461536) (xy 86.702303 115.698037) (xy 86.699039 115.701304) (xy 86.462246 115.858893)
-				(xy 86.45346 115.860624) (xy 86.446024 115.855635) (xy 86.445015 115.853774) (xy 86.272401 115.452212)
-				(xy 86.27145 115.447591) (xy 86.27145 115.169015) (xy 86.274877 115.160742) (xy 86.28315 115.157315)
-			)
-		)
-	)
-	(zone
-		(net 75)
-		(net_name "/MCU/IMU_INT2")
-		(layer "B.Cu")
-		(uuid "18450829-d670-42c1-b0d2-2486e7c54525")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30020)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 82.65 99.405764) (xy 82.35 99.405764) (xy 82.205764 99.941473) (xy 82.5 100.001) (xy 82.794236 99.941473)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 82.649306 99.409191) (xy 82.652331 99.414422) (xy 82.790994 99.929435) (xy 82.789836 99.938315)
-				(xy 82.782738 99.943775) (xy 82.782016 99.943945) (xy 82.50232 100.00053) (xy 82.49768 100.00053)
-				(xy 82.217983 99.943945) (xy 82.210554 99.938945) (xy 82.208835 99.930157) (xy 82.209005 99.929435)
-				(xy 82.347669 99.414422) (xy 82.353129 99.407324) (xy 82.358967 99.405764) (xy 82.641033 99.405764)
+				(xy 77.649306 119.909191) (xy 77.652331 119.914422) (xy 77.790994 120.429435) (xy 77.789836 120.438315)
+				(xy 77.782738 120.443775) (xy 77.782016 120.443945) (xy 77.50232 120.50053) (xy 77.49768 120.50053)
+				(xy 77.217983 120.443945) (xy 77.210554 120.438945) (xy 77.208835 120.430157) (xy 77.209005 120.429435)
+				(xy 77.347669 119.914422) (xy 77.353129 119.907324) (xy 77.358967 119.905764) (xy 77.641033 119.905764)
 			)
 		)
 	)
 	(zone
 		(net 12)
 		(net_name "Net-(U2-SW)")
-		(layer "B.Cu")
-		(uuid "20894a24-414f-44c7-bb57-8dc63d576c55")
+		(layer "F.Cu")
+		(uuid "ee552220-eb75-43f7-aa6d-598cde839e4e")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30002)
+		(priority 30075)
 		(attr
 			(teardrop
 				(type padvia)
@@ -50246,7 +50428,7 @@
 			)
 		)
 		(filled_polygon
-			(layer "B.Cu")
+			(layer "F.Cu")
 			(pts
 				(xy 83.282017 50.356055) (xy 83.289445 50.361054) (xy 83.291164 50.369842) (xy 83.290994 50.370564)
 				(xy 83.152331 50.885578) (xy 83.146871 50.892676) (xy 83.141033 50.894236) (xy 82.858967 50.894236)
@@ -50256,10 +50438,556 @@
 		)
 	)
 	(zone
+		(net 107)
+		(net_name "/MCU/SPI1_NSS")
+		(layer "F.Cu")
+		(uuid "eee6b2c7-1f1d-497b-ae76-4a399529ec2f")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30025)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 78.85 127.094236) (xy 79.15 127.094236) (xy 79.294236 126.558527) (xy 79 126.499) (xy 78.705764 126.558527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 79.282017 126.556055) (xy 79.289445 126.561054) (xy 79.291164 126.569842) (xy 79.290994 126.570564)
+				(xy 79.152331 127.085578) (xy 79.146871 127.092676) (xy 79.141033 127.094236) (xy 78.858967 127.094236)
+				(xy 78.850694 127.090809) (xy 78.847669 127.085578) (xy 78.709005 126.570564) (xy 78.710163 126.561684)
+				(xy 78.717261 126.556224) (xy 78.717953 126.55606) (xy 78.997682 126.499469) (xy 79.002318 126.499469)
+			)
+		)
+	)
+	(zone
+		(net 57)
+		(net_name "/MCU/SERVO_EN")
+		(layer "F.Cu")
+		(uuid "ef4dd0fa-b165-41d9-ae92-2ac2cddf89c3")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30073)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 61.75 86.405764) (xy 61.45 86.405764) (xy 61.305764 86.941473) (xy 61.6 87.001) (xy 61.894236 86.941473)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 61.749306 86.409191) (xy 61.752331 86.414422) (xy 61.890994 86.929435) (xy 61.889836 86.938315)
+				(xy 61.882738 86.943775) (xy 61.882016 86.943945) (xy 61.60232 87.00053) (xy 61.59768 87.00053)
+				(xy 61.317983 86.943945) (xy 61.310554 86.938945) (xy 61.308835 86.930157) (xy 61.309005 86.929435)
+				(xy 61.447669 86.414422) (xy 61.453129 86.407324) (xy 61.458967 86.405764) (xy 61.741033 86.405764)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "f06f7798-4350-4ed2-bd96-8b55b017c811")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30087)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 70.185878 134.973746) (xy 69.973746 135.185878) (xy 70.250559 135.666671) (xy 70.500707 135.500707)
+				(xy 70.666671 135.250559)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 70.193646 134.978218) (xy 70.478798 135.142392) (xy 70.655867 135.244339) (xy 70.661327 135.251437)
+				(xy 70.660169 135.260317) (xy 70.659778 135.260947) (xy 70.502015 135.498734) (xy 70.498734 135.502015)
+				(xy 70.260947 135.659778) (xy 70.252159 135.661497) (xy 70.24473 135.656497) (xy 70.244339 135.655867)
+				(xy 70.016966 135.260947) (xy 69.978218 135.193646) (xy 69.977061 135.184768) (xy 69.980084 135.179539)
+				(xy 70.179538 134.980085) (xy 70.18781 134.976659)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "f610e32b-aa7d-4d6c-acbc-0b58445b8ccd")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30024)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 55.994236 80.404208) (xy 55.994236 80.104208) (xy 55.458527 79.905764) (xy 55.399 80.2) (xy 55.458527 80.494236)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 55.471347 79.910513) (xy 55.9866 80.101379) (xy 55.993168 80.107466) (xy 55.994236 80.11235)
+				(xy 55.994236 80.39431) (xy 55.990809 80.402583) (xy 55.984475 80.405848) (xy 55.469689 80.49236)
+				(xy 55.460962 80.490352) (xy 55.456282 80.483143) (xy 55.399469 80.202318) (xy 55.399469 80.19768)
+				(xy 55.455816 79.919161) (xy 55.460815 79.911735) (xy 55.469603 79.910016)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "+3V3")
+		(layer "F.Cu")
+		(uuid "f6e96f53-3bb7-4a9c-bb76-afdb03e2fc5e")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30082)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 70.834401 136.005976) (xy 71.046533 135.793844) (xy 70.749441 135.333329) (xy 70.499293 135.499293)
+				(xy 70.333329 135.749441)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 70.755782 135.343162) (xy 70.755865 135.343287) (xy 71.041412 135.785907) (xy 71.043017 135.794717)
+				(xy 71.039853 135.800523) (xy 70.840423 135.999953) (xy 70.83215 136.00338) (xy 70.826819 136.002094)
+				(xy 70.344986 135.755409) (xy 70.339184 135.748589) (xy 70.339904 135.739663) (xy 70.340561 135.73854)
+				(xy 70.497985 135.501263) (xy 70.501263 135.497985) (xy 70.739565 135.33988) (xy 70.748353 135.338162)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "fc6f1fb2-986c-4175-ad19-9f0ac740a87f")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30078)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 85.194236 119.8618) (xy 85.194236 119.5618) (xy 84.658527 119.405764) (xy 84.599 119.7) (xy 84.658527 119.994236)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 85.194236 119.5618) (xy 85.194236 119.8618) (xy 84.658527 119.994236) (xy 84.599 119.7) (xy 84.658527 119.405764)
+			)
+		)
+	)
+	(zone
+		(net 107)
+		(net_name "/MCU/SPI1_NSS")
+		(layer "F.Cu")
+		(uuid "fe328369-6b69-41a4-8a97-f273572edb80")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30026)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 76.65 120.405764) (xy 76.35 120.405764) (xy 76.205764 120.941473) (xy 76.5 121.001) (xy 76.794236 120.941473)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 76.649306 120.409191) (xy 76.652331 120.414422) (xy 76.790994 120.929435) (xy 76.789836 120.938315)
+				(xy 76.782738 120.943775) (xy 76.782016 120.943945) (xy 76.50232 121.00053) (xy 76.49768 121.00053)
+				(xy 76.217983 120.943945) (xy 76.210554 120.938945) (xy 76.208835 120.930157) (xy 76.209005 120.929435)
+				(xy 76.347669 120.414422) (xy 76.353129 120.407324) (xy 76.358967 120.405764) (xy 76.641033 120.405764)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "febcc219-9440-4e52-9aa7-e3185f11a0b7")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30052)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 96.9 63.094236) (xy 97.2 63.094236) (xy 97.394236 62.558527) (xy 97.1 62.499) (xy 96.805764 62.558527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 97.394236 62.558527) (xy 97.2 63.094236) (xy 96.9 63.094236) (xy 96.805764 62.558527) (xy 97.1 62.499)
+			)
+		)
+	)
+	(zone
+		(net 31)
+		(net_name "/MCU/SERVO_SIG")
+		(layer "B.Cu")
+		(uuid "01074e2b-dde2-424d-9719-3dfe68f41a6f")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30005)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 62.35 88.594236) (xy 62.65 88.594236) (xy 62.794236 88.058527) (xy 62.5 87.999) (xy 62.205764 88.058527)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 62.782017 88.056055) (xy 62.789445 88.061054) (xy 62.791164 88.069842) (xy 62.790994 88.070564)
+				(xy 62.652331 88.585578) (xy 62.646871 88.592676) (xy 62.641033 88.594236) (xy 62.358967 88.594236)
+				(xy 62.350694 88.590809) (xy 62.347669 88.585578) (xy 62.209005 88.070564) (xy 62.210163 88.061684)
+				(xy 62.217261 88.056224) (xy 62.217953 88.05606) (xy 62.497682 87.999469) (xy 62.502318 87.999469)
+			)
+		)
+	)
+	(zone
+		(net 81)
+		(net_name "/MCU/SPI4_NSS")
+		(layer "B.Cu")
+		(uuid "084010a7-e48b-41e9-b34e-505059019510")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30000)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 85.194236 114.65) (xy 85.194236 114.35) (xy 84.658527 114.205764) (xy 84.599 114.5) (xy 84.658527 114.794236)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 84.670564 114.209005) (xy 84.70391 114.217983) (xy 85.185579 114.347669) (xy 85.192676 114.353128)
+				(xy 85.194236 114.358966) (xy 85.194236 114.641033) (xy 85.190809 114.649306) (xy 85.185578 114.652331)
+				(xy 84.670564 114.790994) (xy 84.661684 114.789836) (xy 84.656224 114.782738) (xy 84.656059 114.782039)
+				(xy 84.599469 114.502318) (xy 84.599469 114.49768) (xy 84.656055 114.21798) (xy 84.661054 114.210554)
+				(xy 84.669842 114.208835)
+			)
+		)
+	)
+	(zone
+		(net 81)
+		(net_name "/MCU/SPI4_NSS")
+		(layer "B.Cu")
+		(uuid "099614ff-8826-467f-85a7-eade358f865e")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30022)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 85.305764 114.35) (xy 85.305764 114.65) (xy 85.841473 114.794236) (xy 85.901 114.5) (xy 85.841473 114.205764)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 85.838315 114.210163) (xy 85.843775 114.217261) (xy 85.843945 114.217983) (xy 85.90053 114.49768)
+				(xy 85.90053 114.50232) (xy 85.843945 114.782016) (xy 85.838945 114.789445) (xy 85.830157 114.791164)
+				(xy 85.829435 114.790994) (xy 85.314422 114.652331) (xy 85.307324 114.646871) (xy 85.305764 114.641033)
+				(xy 85.305764 114.358966) (xy 85.309191 114.350693) (xy 85.314419 114.347669) (xy 85.829435 114.209005)
+			)
+		)
+	)
+	(zone
+		(net 108)
+		(net_name "/MCU/MAG_INT")
+		(layer "B.Cu")
+		(uuid "11986494-8481-4ba8-a0ed-e8451000d1ab")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30010)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 84.943319 118.612445) (xy 84.943319 118.912445) (xy 85.479028 119.056681) (xy 85.538555 118.762445)
+				(xy 85.479028 118.468209)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 85.47587 118.472608) (xy 85.48133 118.479706) (xy 85.4815 118.480428) (xy 85.538085 118.760125)
+				(xy 85.538085 118.764765) (xy 85.4815 119.044461) (xy 85.4765 119.05189) (xy 85.467712 119.053609)
+				(xy 85.46699 119.053439) (xy 84.951977 118.914776) (xy 84.944879 118.909316) (xy 84.943319 118.903478)
+				(xy 84.943319 118.621411) (xy 84.946746 118.613138) (xy 84.951974 118.610114) (xy 85.46699 118.47145)
+			)
+		)
+	)
+	(zone
+		(net 112)
+		(net_name "/MCU/BARO_INT")
+		(layer "B.Cu")
+		(uuid "12da8170-69dd-4ff4-a1b6-b04e18297645")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30033)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 76.386306 112.328749) (xy 76.598438 112.116617) (xy 76.321625 111.635824) (xy 76.071477 111.801788)
+				(xy 75.905513 112.051936)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 76.327453 111.645997) (xy 76.327844 111.646627) (xy 76.593964 112.108846) (xy 76.595122 112.117726)
+				(xy 76.592097 112.122957) (xy 76.392646 112.322408) (xy 76.384373 112.325835) (xy 76.378535 112.324275)
+				(xy 75.916316 112.058155) (xy 75.910856 112.051057) (xy 75.912014 112.042177) (xy 75.912394 112.041563)
+				(xy 76.070169 111.803758) (xy 76.073447 111.80048) (xy 76.311237 111.642715) (xy 76.320024 111.640997)
+			)
+		)
+	)
+	(zone
+		(net 59)
+		(net_name "/MCU/BUZZER")
+		(layer "B.Cu")
+		(uuid "1c541233-8b1e-466a-84bf-6a072a1c5fae")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30016)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 69.85 107.043984) (xy 70.15 107.043984) (xy 70.294236 106.508275) (xy 70 106.448748) (xy 69.705764 106.508275)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 70.282017 106.505803) (xy 70.289445 106.510802) (xy 70.291164 106.51959) (xy 70.290994 106.520312)
+				(xy 70.152331 107.035326) (xy 70.146871 107.042424) (xy 70.141033 107.043984) (xy 69.858967 107.043984)
+				(xy 69.850694 107.040557) (xy 69.847669 107.035326) (xy 69.709005 106.520312) (xy 69.710163 106.511432)
+				(xy 69.717261 106.505972) (xy 69.717953 106.505808) (xy 69.997682 106.449217) (xy 70.002318 106.449217)
+			)
+		)
+	)
+	(zone
 		(net 84)
 		(net_name "/MCU/SPI1_MOSI")
 		(layer "B.Cu")
-		(uuid "212480ef-be10-48a6-810f-a2c88ffdaac8")
+		(uuid "25b21def-13f5-4dc7-964d-ec3c0a4fe386")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30026)
@@ -50297,91 +51025,10 @@
 		)
 	)
 	(zone
-		(net 56)
-		(net_name "/Flash/~{CS}")
-		(layer "B.Cu")
-		(uuid "25d2a99a-7d19-4dd8-92f3-323276802896")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30027)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 73.326254 121.385878) (xy 73.114122 121.173746) (xy 72.633329 121.450559) (xy 72.799293 121.700707)
-				(xy 73.049441 121.866671)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 73.120462 121.180086) (xy 73.319913 121.379537) (xy 73.32334 121.38781) (xy 73.32178 121.393648)
-				(xy 73.05566 121.855867) (xy 73.048562 121.861327) (xy 73.039682 121.860169) (xy 73.039052 121.859778)
-				(xy 72.801265 121.702015) (xy 72.797984 121.698734) (xy 72.640221 121.460947) (xy 72.638502 121.452159)
-				(xy 72.643502 121.44473) (xy 72.644132 121.444339) (xy 73.106353 121.178218) (xy 73.115231 121.177061)
-			)
-		)
-	)
-	(zone
-		(net 116)
-		(net_name "/MCU/SPI1_SCK")
-		(layer "B.Cu")
-		(uuid "2c6386f9-a4ae-4564-aecd-2ad90ce7a68a")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30037)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 82.185878 124.973746) (xy 81.973746 125.185878) (xy 82.250559 125.666671) (xy 82.500707 125.500707)
-				(xy 82.666671 125.250559)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 82.193646 124.978218) (xy 82.478798 125.142392) (xy 82.655867 125.244339) (xy 82.661327 125.251437)
-				(xy 82.660169 125.260317) (xy 82.659778 125.260947) (xy 82.502015 125.498734) (xy 82.498734 125.502015)
-				(xy 82.260947 125.659778) (xy 82.252159 125.661497) (xy 82.24473 125.656497) (xy 82.244339 125.655867)
-				(xy 82.016966 125.260947) (xy 81.978218 125.193646) (xy 81.977061 125.184768) (xy 81.980084 125.179539)
-				(xy 82.179538 124.980085) (xy 82.18781 124.976659)
-			)
-		)
-	)
-	(zone
 		(net 31)
 		(net_name "/MCU/SERVO_SIG")
 		(layer "B.Cu")
-		(uuid "3bd8175d-e008-41a0-b4aa-5e5b09078b1d")
+		(uuid "26714186-d608-4218-a7cd-17eaf19880e7")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30004)
@@ -50403,55 +51050,16 @@
 		)
 		(polygon
 			(pts
-				(xy 62.35 88.594236) (xy 62.65 88.594236) (xy 62.794236 88.058527) (xy 62.5 87.999) (xy 62.205764 88.058527)
+				(xy 62.65 95.905764) (xy 62.35 95.905764) (xy 62.205764 96.441473) (xy 62.5 96.501) (xy 62.794236 96.441473)
 			)
 		)
 		(filled_polygon
 			(layer "B.Cu")
 			(pts
-				(xy 62.782017 88.056055) (xy 62.789445 88.061054) (xy 62.791164 88.069842) (xy 62.790994 88.070564)
-				(xy 62.652331 88.585578) (xy 62.646871 88.592676) (xy 62.641033 88.594236) (xy 62.358967 88.594236)
-				(xy 62.350694 88.590809) (xy 62.347669 88.585578) (xy 62.209005 88.070564) (xy 62.210163 88.061684)
-				(xy 62.217261 88.056224) (xy 62.217953 88.05606) (xy 62.497682 87.999469) (xy 62.502318 87.999469)
-			)
-		)
-	)
-	(zone
-		(net 56)
-		(net_name "/Flash/~{CS}")
-		(layer "B.Cu")
-		(uuid "3da26e72-8e61-483f-9b88-db901f1059e5")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30009)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 73.15 112.794236) (xy 73.45 112.794236) (xy 73.594236 112.258527) (xy 73.3 112.199) (xy 73.005764 112.258527)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 73.582017 112.256055) (xy 73.589445 112.261054) (xy 73.591164 112.269842) (xy 73.590994 112.270564)
-				(xy 73.452331 112.785578) (xy 73.446871 112.792676) (xy 73.441033 112.794236) (xy 73.158967 112.794236)
-				(xy 73.150694 112.790809) (xy 73.147669 112.785578) (xy 73.009005 112.270564) (xy 73.010163 112.261684)
-				(xy 73.017261 112.256224) (xy 73.017953 112.25606) (xy 73.297682 112.199469) (xy 73.302318 112.199469)
+				(xy 62.649306 95.909191) (xy 62.652331 95.914422) (xy 62.790994 96.429435) (xy 62.789836 96.438315)
+				(xy 62.782738 96.443775) (xy 62.782016 96.443945) (xy 62.50232 96.50053) (xy 62.49768 96.50053)
+				(xy 62.217983 96.443945) (xy 62.210554 96.438945) (xy 62.208835 96.430157) (xy 62.209005 96.429435)
+				(xy 62.347669 95.914422) (xy 62.353129 95.907324) (xy 62.358967 95.905764) (xy 62.641033 95.905764)
 			)
 		)
 	)
@@ -50459,364 +51067,10 @@
 		(net 57)
 		(net_name "/MCU/SERVO_EN")
 		(layer "B.Cu")
-		(uuid "3fa60542-97a3-44e2-b845-23d8577cb20a")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30015)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 90.605764 63.35) (xy 90.605764 63.65) (xy 91.141473 63.794236) (xy 91.201 63.5) (xy 91.141473 63.205764)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 91.138315 63.210163) (xy 91.143775 63.217261) (xy 91.143945 63.217983) (xy 91.20053 63.49768)
-				(xy 91.20053 63.50232) (xy 91.143945 63.782016) (xy 91.138945 63.789445) (xy 91.130157 63.791164)
-				(xy 91.129435 63.790994) (xy 90.614422 63.652331) (xy 90.607324 63.646871) (xy 90.605764 63.641033)
-				(xy 90.605764 63.358966) (xy 90.609191 63.350693) (xy 90.614419 63.347669) (xy 91.129435 63.209005)
-			)
-		)
-	)
-	(zone
-		(net 108)
-		(net_name "/MCU/MAG_INT")
-		(layer "B.Cu")
-		(uuid "458141c3-bdb1-45b7-b2db-28010ec19867")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30017)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 78.65 109.494236) (xy 78.95 109.494236) (xy 79.094236 108.958527) (xy 78.8 108.899) (xy 78.505764 108.958527)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 79.082017 108.956055) (xy 79.089445 108.961054) (xy 79.091164 108.969842) (xy 79.090994 108.970564)
-				(xy 78.952331 109.485578) (xy 78.946871 109.492676) (xy 78.941033 109.494236) (xy 78.658967 109.494236)
-				(xy 78.650694 109.490809) (xy 78.647669 109.485578) (xy 78.509005 108.970564) (xy 78.510163 108.961684)
-				(xy 78.517261 108.956224) (xy 78.517953 108.95606) (xy 78.797682 108.899469) (xy 78.802318 108.899469)
-			)
-		)
-	)
-	(zone
-		(net 55)
-		(net_name "/Flash/IO3")
-		(layer "B.Cu")
-		(uuid "4ecc4a65-feec-4ca3-85e3-cd75e65f90f9")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30008)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 61.85 128.69621) (xy 62.15 128.69621) (xy 62.294236 128.160501) (xy 62 128.100974) (xy 61.705764 128.160501)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 62.282017 128.158029) (xy 62.289445 128.163028) (xy 62.291164 128.171816) (xy 62.290994 128.172538)
-				(xy 62.152331 128.687552) (xy 62.146871 128.69465) (xy 62.141033 128.69621) (xy 61.858967 128.69621)
-				(xy 61.850694 128.692783) (xy 61.847669 128.687552) (xy 61.709005 128.172538) (xy 61.710163 128.163658)
-				(xy 61.717261 128.158198) (xy 61.717953 128.158034) (xy 61.997682 128.101443) (xy 62.002318 128.101443)
-			)
-		)
-	)
-	(zone
-		(net 128)
-		(net_name "/MCU/SERVO_FDBK")
-		(layer "B.Cu")
-		(uuid "4ed9fc4b-971c-40fb-8414-14616359a594")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30023)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 79.15 102.405764) (xy 78.85 102.405764) (xy 78.705764 102.941473) (xy 79 103.001) (xy 79.294236 102.941473)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 79.149306 102.409191) (xy 79.152331 102.414422) (xy 79.290994 102.929435) (xy 79.289836 102.938315)
-				(xy 79.282738 102.943775) (xy 79.282016 102.943945) (xy 79.00232 103.00053) (xy 78.99768 103.00053)
-				(xy 78.717983 102.943945) (xy 78.710554 102.938945) (xy 78.708835 102.930157) (xy 78.709005 102.929435)
-				(xy 78.847669 102.414422) (xy 78.853129 102.407324) (xy 78.858967 102.405764) (xy 79.141033 102.405764)
-			)
-		)
-	)
-	(zone
-		(net 102)
-		(net_name "/MCU/SPI2_NSS")
-		(layer "B.Cu")
-		(uuid "4fe39331-9103-4d00-b695-cc945336506b")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30034)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 84.814122 99.526254) (xy 85.026254 99.314122) (xy 84.749441 98.833329) (xy 84.499293 98.999293)
-				(xy 84.333329 99.249441)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 84.755269 98.843502) (xy 84.75566 98.844132) (xy 85.02178 99.306351) (xy 85.022938 99.315231)
-				(xy 85.019913 99.320462) (xy 84.820462 99.519913) (xy 84.812189 99.52334) (xy 84.806351 99.52178)
-				(xy 84.344132 99.25566) (xy 84.338672 99.248562) (xy 84.33983 99.239682) (xy 84.34021 99.239068)
-				(xy 84.497985 99.001263) (xy 84.501263 98.997985) (xy 84.739053 98.84022) (xy 84.74784 98.838502)
-			)
-		)
-	)
-	(zone
-		(net 57)
-		(net_name "/MCU/SERVO_EN")
-		(layer "B.Cu")
-		(uuid "5d00abff-58da-40a6-afca-1ec882b6eaaa")
+		(uuid "28396145-6d01-4200-8b09-60f68836f32d")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30012)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 61.75 95.905764) (xy 61.45 95.905764) (xy 61.305764 96.441473) (xy 61.6 96.501) (xy 61.894236 96.441473)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 61.749306 95.909191) (xy 61.752331 95.914422) (xy 61.890994 96.429435) (xy 61.889836 96.438315)
-				(xy 61.882738 96.443775) (xy 61.882016 96.443945) (xy 61.60232 96.50053) (xy 61.59768 96.50053)
-				(xy 61.317983 96.443945) (xy 61.310554 96.438945) (xy 61.308835 96.430157) (xy 61.309005 96.429435)
-				(xy 61.447669 95.914422) (xy 61.453129 95.907324) (xy 61.458967 95.905764) (xy 61.741033 95.905764)
-			)
-		)
-	)
-	(zone
-		(net 112)
-		(net_name "/MCU/BARO_INT")
-		(layer "B.Cu")
-		(uuid "609cb0f2-ff00-4538-9ba9-c2fb41919f56")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30033)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 76.386306 112.328749) (xy 76.598438 112.116617) (xy 76.321625 111.635824) (xy 76.071477 111.801788)
-				(xy 75.905513 112.051936)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 76.327453 111.645997) (xy 76.327844 111.646627) (xy 76.593964 112.108846) (xy 76.595122 112.117726)
-				(xy 76.592097 112.122957) (xy 76.392646 112.322408) (xy 76.384373 112.325835) (xy 76.378535 112.324275)
-				(xy 75.916316 112.058155) (xy 75.910856 112.051057) (xy 75.912014 112.042177) (xy 75.912394 112.041563)
-				(xy 76.070169 111.803758) (xy 76.073447 111.80048) (xy 76.311237 111.642715) (xy 76.320024 111.640997)
-			)
-		)
-	)
-	(zone
-		(net 13)
-		(net_name "/MCU/BATT_VSENSE")
-		(layer "B.Cu")
-		(uuid "60f23a1e-fccc-4ba5-92ab-fbc763064265")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30014)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 78.15 100.405764) (xy 77.85 100.405764) (xy 77.705764 100.941473) (xy 78 101.001) (xy 78.294236 100.941473)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 78.149306 100.409191) (xy 78.152331 100.414422) (xy 78.290994 100.929435) (xy 78.289836 100.938315)
-				(xy 78.282738 100.943775) (xy 78.282016 100.943945) (xy 78.00232 101.00053) (xy 77.99768 101.00053)
-				(xy 77.717983 100.943945) (xy 77.710554 100.938945) (xy 77.708835 100.930157) (xy 77.709005 100.929435)
-				(xy 77.847669 100.414422) (xy 77.853129 100.407324) (xy 77.858967 100.405764) (xy 78.141033 100.405764)
-			)
-		)
-	)
-	(zone
-		(net 108)
-		(net_name "/MCU/MAG_INT")
-		(layer "B.Cu")
-		(uuid "62c3f915-ff50-4ced-9f2f-8655ee93f517")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30010)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 84.943319 118.612445) (xy 84.943319 118.912445) (xy 85.479028 119.056681) (xy 85.538555 118.762445)
-				(xy 85.479028 118.468209)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 85.47587 118.472608) (xy 85.48133 118.479706) (xy 85.4815 118.480428) (xy 85.538085 118.760125)
-				(xy 85.538085 118.764765) (xy 85.4815 119.044461) (xy 85.4765 119.05189) (xy 85.467712 119.053609)
-				(xy 85.46699 119.053439) (xy 84.951977 118.914776) (xy 84.944879 118.909316) (xy 84.943319 118.903478)
-				(xy 84.943319 118.621411) (xy 84.946746 118.613138) (xy 84.951974 118.610114) (xy 85.46699 118.47145)
-			)
-		)
-	)
-	(zone
-		(net 57)
-		(net_name "/MCU/SERVO_EN")
-		(layer "B.Cu")
-		(uuid "6d1b5926-1fa6-4e49-8d55-ec874453ec34")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30013)
 		(attr
 			(teardrop
 				(type padvia)
@@ -50849,10 +51103,88 @@
 		)
 	)
 	(zone
+		(net 87)
+		(net_name "/MCU/BATT_ISENSE")
+		(layer "B.Cu")
+		(uuid "30339f36-7558-4935-9f2a-0b5216744d31")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30003)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 91.35 75.794236) (xy 91.65 75.794236) (xy 91.794236 75.258527) (xy 91.5 75.199) (xy 91.205764 75.258527)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 91.782017 75.256055) (xy 91.789445 75.261054) (xy 91.791164 75.269842) (xy 91.790994 75.270564)
+				(xy 91.652331 75.785578) (xy 91.646871 75.792676) (xy 91.641033 75.794236) (xy 91.358967 75.794236)
+				(xy 91.350694 75.790809) (xy 91.347669 75.785578) (xy 91.209005 75.270564) (xy 91.210163 75.261684)
+				(xy 91.217261 75.256224) (xy 91.217953 75.25606) (xy 91.497682 75.199469) (xy 91.502318 75.199469)
+			)
+		)
+	)
+	(zone
+		(net 12)
+		(net_name "Net-(U2-SW)")
+		(layer "B.Cu")
+		(uuid "320b6c8d-cf1f-4c28-a4c2-4715cbb9e8de")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30002)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 82.85 50.894236) (xy 83.15 50.894236) (xy 83.294236 50.358527) (xy 83 50.299) (xy 82.705764 50.358527)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 83.282017 50.356055) (xy 83.289445 50.361054) (xy 83.291164 50.369842) (xy 83.290994 50.370564)
+				(xy 83.152331 50.885578) (xy 83.146871 50.892676) (xy 83.141033 50.894236) (xy 82.858967 50.894236)
+				(xy 82.850694 50.890809) (xy 82.847669 50.885578) (xy 82.709005 50.370564) (xy 82.710163 50.361684)
+				(xy 82.717261 50.356224) (xy 82.717953 50.35606) (xy 82.997682 50.299469) (xy 83.002318 50.299469)
+			)
+		)
+	)
+	(zone
 		(net 13)
 		(net_name "/MCU/BATT_VSENSE")
 		(layer "B.Cu")
-		(uuid "70fde636-b96c-45e1-8578-08daefc00c38")
+		(uuid "326edee0-f007-4ea9-b6fa-150c2e0ce913")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30045)
@@ -50889,13 +51221,13 @@
 		)
 	)
 	(zone
-		(net 116)
-		(net_name "/MCU/SPI1_SCK")
+		(net 75)
+		(net_name "/MCU/IMU_INT2")
 		(layer "B.Cu")
-		(uuid "728c4c8c-2051-4126-9e5f-85c824dd0c63")
+		(uuid "37c7137c-7015-4d0a-9591-350cf14910dc")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30038)
+		(priority 30021)
 		(attr
 			(teardrop
 				(type padvia)
@@ -50914,28 +51246,27 @@
 		)
 		(polygon
 			(pts
-				(xy 77.814122 121.026254) (xy 78.026254 120.814122) (xy 77.749441 120.333329) (xy 77.499293 120.499293)
-				(xy 77.333329 120.749441)
+				(xy 91.6 82.844237) (xy 91.9 82.844237) (xy 92.044236 82.308528) (xy 91.75 82.249001) (xy 91.455764 82.308528)
 			)
 		)
 		(filled_polygon
 			(layer "B.Cu")
 			(pts
-				(xy 77.755269 120.343502) (xy 77.75566 120.344132) (xy 78.02178 120.806351) (xy 78.022938 120.815231)
-				(xy 78.019913 120.820462) (xy 77.820462 121.019913) (xy 77.812189 121.02334) (xy 77.806351 121.02178)
-				(xy 77.344132 120.75566) (xy 77.338672 120.748562) (xy 77.33983 120.739682) (xy 77.34021 120.739068)
-				(xy 77.497985 120.501263) (xy 77.501263 120.497985) (xy 77.739053 120.34022) (xy 77.74784 120.338502)
+				(xy 92.032017 82.306056) (xy 92.039445 82.311055) (xy 92.041164 82.319843) (xy 92.040994 82.320565)
+				(xy 91.902331 82.835579) (xy 91.896871 82.842677) (xy 91.891033 82.844237) (xy 91.608967 82.844237)
+				(xy 91.600694 82.84081) (xy 91.597669 82.835579) (xy 91.459005 82.320565) (xy 91.460163 82.311685)
+				(xy 91.467261 82.306225) (xy 91.467953 82.306061) (xy 91.747682 82.24947) (xy 91.752318 82.24947)
 			)
 		)
 	)
 	(zone
-		(net 49)
-		(net_name "/MCU/BOOT0")
+		(net 56)
+		(net_name "/Flash/~{CS}")
 		(layer "B.Cu")
-		(uuid "7448b801-f48d-438d-ac10-d4cfe6d311b9")
+		(uuid "397d79a8-307a-4069-be22-6c1992597664")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30011)
+		(priority 30027)
 		(attr
 			(teardrop
 				(type padvia)
@@ -50954,27 +51285,28 @@
 		)
 		(polygon
 			(pts
-				(xy 65.05 100.894236) (xy 65.35 100.894236) (xy 65.494236 100.358527) (xy 65.2 100.299) (xy 64.905764 100.358527)
+				(xy 73.326254 121.385878) (xy 73.114122 121.173746) (xy 72.633329 121.450559) (xy 72.799293 121.700707)
+				(xy 73.049441 121.866671)
 			)
 		)
 		(filled_polygon
 			(layer "B.Cu")
 			(pts
-				(xy 65.482017 100.356055) (xy 65.489445 100.361054) (xy 65.491164 100.369842) (xy 65.490994 100.370564)
-				(xy 65.352331 100.885578) (xy 65.346871 100.892676) (xy 65.341033 100.894236) (xy 65.058967 100.894236)
-				(xy 65.050694 100.890809) (xy 65.047669 100.885578) (xy 64.909005 100.370564) (xy 64.910163 100.361684)
-				(xy 64.917261 100.356224) (xy 64.917953 100.35606) (xy 65.197682 100.299469) (xy 65.202318 100.299469)
+				(xy 73.120462 121.180086) (xy 73.319913 121.379537) (xy 73.32334 121.38781) (xy 73.32178 121.393648)
+				(xy 73.05566 121.855867) (xy 73.048562 121.861327) (xy 73.039682 121.860169) (xy 73.039052 121.859778)
+				(xy 72.801265 121.702015) (xy 72.797984 121.698734) (xy 72.640221 121.460947) (xy 72.638502 121.452159)
+				(xy 72.643502 121.44473) (xy 72.644132 121.444339) (xy 73.106353 121.178218) (xy 73.115231 121.177061)
 			)
 		)
 	)
 	(zone
-		(net 107)
-		(net_name "/MCU/SPI1_NSS")
+		(net 109)
+		(net_name "/MCU/SPI1_MISO")
 		(layer "B.Cu")
-		(uuid "7a7ebba5-d36f-4e67-8a5c-d21f15bee028")
+		(uuid "3c1969df-442e-4c77-b644-617513a148c1")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30006)
+		(priority 30028)
 		(attr
 			(teardrop
 				(type padvia)
@@ -50993,27 +51325,28 @@
 		)
 		(polygon
 			(pts
-				(xy 76.35 121.594236) (xy 76.65 121.594236) (xy 76.794236 121.058527) (xy 76.5 120.999) (xy 76.205764 121.058527)
+				(xy 78.014122 115.026254) (xy 78.226254 114.814122) (xy 77.949441 114.333329) (xy 77.699293 114.499293)
+				(xy 77.533329 114.749441)
 			)
 		)
 		(filled_polygon
 			(layer "B.Cu")
 			(pts
-				(xy 76.782017 121.056055) (xy 76.789445 121.061054) (xy 76.791164 121.069842) (xy 76.790994 121.070564)
-				(xy 76.652331 121.585578) (xy 76.646871 121.592676) (xy 76.641033 121.594236) (xy 76.358967 121.594236)
-				(xy 76.350694 121.590809) (xy 76.347669 121.585578) (xy 76.209005 121.070564) (xy 76.210163 121.061684)
-				(xy 76.217261 121.056224) (xy 76.217953 121.05606) (xy 76.497682 120.999469) (xy 76.502318 120.999469)
+				(xy 77.955269 114.343502) (xy 77.95566 114.344132) (xy 78.22178 114.806351) (xy 78.222938 114.815231)
+				(xy 78.219913 114.820462) (xy 78.020462 115.019913) (xy 78.012189 115.02334) (xy 78.006351 115.02178)
+				(xy 77.544132 114.75566) (xy 77.538672 114.748562) (xy 77.53983 114.739682) (xy 77.54021 114.739068)
+				(xy 77.697985 114.501263) (xy 77.701263 114.497985) (xy 77.939053 114.34022) (xy 77.94784 114.338502)
 			)
 		)
 	)
 	(zone
-		(net 87)
-		(net_name "/MCU/BATT_ISENSE")
+		(net 102)
+		(net_name "/MCU/SPI2_NSS")
 		(layer "B.Cu")
-		(uuid "824f8562-2653-4f2d-93ce-6b4f3c3c2375")
+		(uuid "3f9f826a-290c-4ac9-a6d7-5c37f5f93bf3")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30003)
+		(priority 30034)
 		(attr
 			(teardrop
 				(type padvia)
@@ -51032,55 +51365,17 @@
 		)
 		(polygon
 			(pts
-				(xy 91.35 75.794236) (xy 91.65 75.794236) (xy 91.794236 75.258527) (xy 91.5 75.199) (xy 91.205764 75.258527)
+				(xy 84.814122 99.526254) (xy 85.026254 99.314122) (xy 84.749441 98.833329) (xy 84.499293 98.999293)
+				(xy 84.333329 99.249441)
 			)
 		)
 		(filled_polygon
 			(layer "B.Cu")
 			(pts
-				(xy 91.782017 75.256055) (xy 91.789445 75.261054) (xy 91.791164 75.269842) (xy 91.790994 75.270564)
-				(xy 91.652331 75.785578) (xy 91.646871 75.792676) (xy 91.641033 75.794236) (xy 91.358967 75.794236)
-				(xy 91.350694 75.790809) (xy 91.347669 75.785578) (xy 91.209005 75.270564) (xy 91.210163 75.261684)
-				(xy 91.217261 75.256224) (xy 91.217953 75.25606) (xy 91.497682 75.199469) (xy 91.502318 75.199469)
-			)
-		)
-	)
-	(zone
-		(net 59)
-		(net_name "/MCU/BUZZER")
-		(layer "B.Cu")
-		(uuid "83dda119-afd9-4d4b-9e1b-c0629b87e9c1")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30016)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 69.85 107.043984) (xy 70.15 107.043984) (xy 70.294236 106.508275) (xy 70 106.448748) (xy 69.705764 106.508275)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 70.282017 106.505803) (xy 70.289445 106.510802) (xy 70.291164 106.51959) (xy 70.290994 106.520312)
-				(xy 70.152331 107.035326) (xy 70.146871 107.042424) (xy 70.141033 107.043984) (xy 69.858967 107.043984)
-				(xy 69.850694 107.040557) (xy 69.847669 107.035326) (xy 69.709005 106.520312) (xy 69.710163 106.511432)
-				(xy 69.717261 106.505972) (xy 69.717953 106.505808) (xy 69.997682 106.449217) (xy 70.002318 106.449217)
+				(xy 84.755269 98.843502) (xy 84.75566 98.844132) (xy 85.02178 99.306351) (xy 85.022938 99.315231)
+				(xy 85.019913 99.320462) (xy 84.820462 99.519913) (xy 84.812189 99.52334) (xy 84.806351 99.52178)
+				(xy 84.344132 99.25566) (xy 84.338672 99.248562) (xy 84.33983 99.239682) (xy 84.34021 99.239068)
+				(xy 84.497985 99.001263) (xy 84.501263 98.997985) (xy 84.739053 98.84022) (xy 84.74784 98.838502)
 			)
 		)
 	)
@@ -51088,7 +51383,7 @@
 		(net 114)
 		(net_name "/MCU/IMU_INT1")
 		(layer "B.Cu")
-		(uuid "8c70857c-b731-4553-a788-c7625603635d")
+		(uuid "44c72466-4599-4393-b9b7-e7d32fd605c7")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30018)
@@ -51124,10 +51419,50 @@
 		)
 	)
 	(zone
+		(net 84)
+		(net_name "/MCU/SPI1_MOSI")
+		(layer "B.Cu")
+		(uuid "4519c630-57c9-4316-a59d-16919db38ca2")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30044)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 78.175214 113.887345) (xy 78.387345 113.675214) (xy 77.758527 113.455765) (xy 77.699293 113.749294)
+				(xy 77.758527 114.044237)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 77.771191 113.460184) (xy 78.369749 113.669073) (xy 78.37643 113.675034) (xy 78.37694 113.683974)
+				(xy 78.374166 113.688392) (xy 78.177001 113.885557) (xy 78.172851 113.888234) (xy 77.77141 114.039386)
+				(xy 77.76246 114.039094) (xy 77.756337 114.032559) (xy 77.755816 114.03074) (xy 77.699756 113.751599)
+				(xy 77.699757 113.746989) (xy 77.755872 113.468917) (xy 77.760868 113.461487) (xy 77.769655 113.459764)
+			)
+		)
+	)
+	(zone
 		(net 87)
 		(net_name "/MCU/BATT_ISENSE")
 		(layer "B.Cu")
-		(uuid "92ab72a7-a8ee-454b-a93c-c5dc0d98d66c")
+		(uuid "4c8882f3-98ed-434c-8187-37b1b1faf29a")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30025)
@@ -51165,10 +51500,246 @@
 		)
 	)
 	(zone
+		(net 114)
+		(net_name "/MCU/IMU_INT1")
+		(layer "B.Cu")
+		(uuid "6133d5e0-5f74-47fa-9475-be881c1372d6")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30019)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 92.205764 87.85) (xy 92.205764 88.15) (xy 92.741473 88.294236) (xy 92.801 88) (xy 92.741473 87.705764)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 92.738315 87.710163) (xy 92.743775 87.717261) (xy 92.743945 87.717983) (xy 92.80053 87.99768)
+				(xy 92.80053 88.00232) (xy 92.743945 88.282016) (xy 92.738945 88.289445) (xy 92.730157 88.291164)
+				(xy 92.729435 88.290994) (xy 92.214422 88.152331) (xy 92.207324 88.146871) (xy 92.205764 88.141033)
+				(xy 92.205764 87.858966) (xy 92.209191 87.850693) (xy 92.214419 87.847669) (xy 92.729435 87.709005)
+			)
+		)
+	)
+	(zone
+		(net 31)
+		(net_name "/MCU/SERVO_SIG")
+		(layer "B.Cu")
+		(uuid "61ba4ded-7cdd-42e5-84d3-ab0ef7880cf2")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30030)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 73.526254 75.185878) (xy 73.314122 74.973746) (xy 72.833329 75.250559) (xy 72.999293 75.500707)
+				(xy 73.249441 75.666671)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 73.320462 74.980086) (xy 73.519913 75.179537) (xy 73.52334 75.18781) (xy 73.52178 75.193648)
+				(xy 73.25566 75.655867) (xy 73.248562 75.661327) (xy 73.239682 75.660169) (xy 73.239052 75.659778)
+				(xy 73.001265 75.502015) (xy 72.997984 75.498734) (xy 72.840221 75.260947) (xy 72.838502 75.252159)
+				(xy 72.843502 75.24473) (xy 72.844132 75.244339) (xy 73.306353 74.978218) (xy 73.315231 74.977061)
+			)
+		)
+	)
+	(zone
+		(net 82)
+		(net_name "/MCU/SPI4_SCK")
+		(layer "B.Cu")
+		(uuid "64e3b45d-d383-4758-9937-e745dd1f2b9d")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30036)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 83.414122 114.626254) (xy 83.626254 114.414122) (xy 83.349441 113.933329) (xy 83.099293 114.099293)
+				(xy 82.933329 114.349441)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 83.355269 113.943502) (xy 83.35566 113.944132) (xy 83.62178 114.406351) (xy 83.622938 114.415231)
+				(xy 83.619913 114.420462) (xy 83.420462 114.619913) (xy 83.412189 114.62334) (xy 83.406351 114.62178)
+				(xy 82.944132 114.35566) (xy 82.938672 114.348562) (xy 82.93983 114.339682) (xy 82.94021 114.339068)
+				(xy 83.097985 114.101263) (xy 83.101263 114.097985) (xy 83.339053 113.94022) (xy 83.34784 113.938502)
+			)
+		)
+	)
+	(zone
+		(net 82)
+		(net_name "/MCU/SPI4_SCK")
+		(layer "B.Cu")
+		(uuid "6519a5ab-668d-4271-8208-99c5409e2d73")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30043)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 86.27145 115.15) (xy 86.27145 115.45) (xy 86.450559 115.866671) (xy 86.701 115.7) (xy 86.866671 115.450559)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 86.288424 115.158571) (xy 86.854908 115.444619) (xy 86.860748 115.451407) (xy 86.860078 115.460337)
+				(xy 86.85938 115.461536) (xy 86.702303 115.698037) (xy 86.699039 115.701304) (xy 86.462246 115.858893)
+				(xy 86.45346 115.860624) (xy 86.446024 115.855635) (xy 86.445015 115.853774) (xy 86.272401 115.452212)
+				(xy 86.27145 115.447591) (xy 86.27145 115.169015) (xy 86.274877 115.160742) (xy 86.28315 115.157315)
+			)
+		)
+	)
+	(zone
+		(net 107)
+		(net_name "/MCU/SPI1_NSS")
+		(layer "B.Cu")
+		(uuid "670031f8-39ca-4d7f-a167-180f17d3d989")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30006)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 76.35 121.594236) (xy 76.65 121.594236) (xy 76.794236 121.058527) (xy 76.5 120.999) (xy 76.205764 121.058527)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 76.782017 121.056055) (xy 76.789445 121.061054) (xy 76.791164 121.069842) (xy 76.790994 121.070564)
+				(xy 76.652331 121.585578) (xy 76.646871 121.592676) (xy 76.641033 121.594236) (xy 76.358967 121.594236)
+				(xy 76.350694 121.590809) (xy 76.347669 121.585578) (xy 76.209005 121.070564) (xy 76.210163 121.061684)
+				(xy 76.217261 121.056224) (xy 76.217953 121.05606) (xy 76.497682 120.999469) (xy 76.502318 120.999469)
+			)
+		)
+	)
+	(zone
+		(net 12)
+		(net_name "Net-(U2-SW)")
+		(layer "B.Cu")
+		(uuid "6e1aa6af-9dd3-46a3-8ec7-ef7befd2f151")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30001)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 86.705764 53.45) (xy 86.705764 53.75) (xy 87.241473 53.894236) (xy 87.301 53.6) (xy 87.241473 53.305764)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 87.238315 53.310163) (xy 87.243775 53.317261) (xy 87.243945 53.317983) (xy 87.30053 53.59768)
+				(xy 87.30053 53.60232) (xy 87.243945 53.882016) (xy 87.238945 53.889445) (xy 87.230157 53.891164)
+				(xy 87.229435 53.890994) (xy 86.714422 53.752331) (xy 86.707324 53.746871) (xy 86.705764 53.741033)
+				(xy 86.705764 53.458966) (xy 86.709191 53.450693) (xy 86.714419 53.447669) (xy 87.229435 53.309005)
+			)
+		)
+	)
+	(zone
 		(net 59)
 		(net_name "/MCU/BUZZER")
 		(layer "B.Cu")
-		(uuid "938ca1b4-b242-4367-97a4-900ce6315c2d")
+		(uuid "798cfb84-8d6c-453e-ae70-cef9efc92106")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30042)
@@ -51202,6 +51773,328 @@
 				(xy 73.760947 129.259778) (xy 73.752159 129.261497) (xy 73.74473 129.256497) (xy 73.744339 129.255867)
 				(xy 73.516966 128.860947) (xy 73.478218 128.793646) (xy 73.477061 128.784768) (xy 73.480084 128.779539)
 				(xy 73.679538 128.580085) (xy 73.68781 128.576659)
+			)
+		)
+	)
+	(zone
+		(net 56)
+		(net_name "/Flash/~{CS}")
+		(layer "B.Cu")
+		(uuid "7d10979e-44a6-4a94-ab15-4cabbaaf1edb")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30009)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 73.15 112.794236) (xy 73.45 112.794236) (xy 73.594236 112.258527) (xy 73.3 112.199) (xy 73.005764 112.258527)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 73.582017 112.256055) (xy 73.589445 112.261054) (xy 73.591164 112.269842) (xy 73.590994 112.270564)
+				(xy 73.452331 112.785578) (xy 73.446871 112.792676) (xy 73.441033 112.794236) (xy 73.158967 112.794236)
+				(xy 73.150694 112.790809) (xy 73.147669 112.785578) (xy 73.009005 112.270564) (xy 73.010163 112.261684)
+				(xy 73.017261 112.256224) (xy 73.017953 112.25606) (xy 73.297682 112.199469) (xy 73.302318 112.199469)
+			)
+		)
+	)
+	(zone
+		(net 112)
+		(net_name "/MCU/BARO_INT")
+		(layer "B.Cu")
+		(uuid "7de98172-ffb6-4081-aec6-c0b0d4a1a8b4")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30032)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 77.485878 136.273746) (xy 77.273746 136.485878) (xy 77.550559 136.966671) (xy 77.800707 136.800707)
+				(xy 77.966671 136.550559)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 77.493646 136.278218) (xy 77.778798 136.442392) (xy 77.955867 136.544339) (xy 77.961327 136.551437)
+				(xy 77.960169 136.560317) (xy 77.959778 136.560947) (xy 77.802015 136.798734) (xy 77.798734 136.802015)
+				(xy 77.560947 136.959778) (xy 77.552159 136.961497) (xy 77.54473 136.956497) (xy 77.544339 136.955867)
+				(xy 77.316966 136.560947) (xy 77.278218 136.493646) (xy 77.277061 136.484768) (xy 77.280084 136.479539)
+				(xy 77.479538 136.280085) (xy 77.48781 136.276659)
+			)
+		)
+	)
+	(zone
+		(net 57)
+		(net_name "/MCU/SERVO_EN")
+		(layer "B.Cu")
+		(uuid "85ea0dd6-7779-4cba-b508-138b2c14301c")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30024)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 72.526254 74.185878) (xy 72.314122 73.973746) (xy 71.833329 74.250559) (xy 71.999293 74.500707)
+				(xy 72.249441 74.666671)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 72.320462 73.980086) (xy 72.519913 74.179537) (xy 72.52334 74.18781) (xy 72.52178 74.193648)
+				(xy 72.25566 74.655867) (xy 72.248562 74.661327) (xy 72.239682 74.660169) (xy 72.239052 74.659778)
+				(xy 72.001265 74.502015) (xy 71.997984 74.498734) (xy 71.840221 74.260947) (xy 71.838502 74.252159)
+				(xy 71.843502 74.24473) (xy 71.844132 74.244339) (xy 72.306353 73.978218) (xy 72.315231 73.977061)
+			)
+		)
+	)
+	(zone
+		(net 109)
+		(net_name "/MCU/SPI1_MISO")
+		(layer "B.Cu")
+		(uuid "88a18c77-862f-4647-a178-e7482eecf129")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30029)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 80.185878 116.773746) (xy 79.973746 116.985878) (xy 80.250559 117.466671) (xy 80.500707 117.300707)
+				(xy 80.666671 117.050559)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 80.193646 116.778218) (xy 80.478798 116.942392) (xy 80.655867 117.044339) (xy 80.661327 117.051437)
+				(xy 80.660169 117.060317) (xy 80.659778 117.060947) (xy 80.502015 117.298734) (xy 80.498734 117.302015)
+				(xy 80.260947 117.459778) (xy 80.252159 117.461497) (xy 80.24473 117.456497) (xy 80.244339 117.455867)
+				(xy 80.016966 117.060947) (xy 79.978218 116.993646) (xy 79.977061 116.984768) (xy 79.980084 116.979539)
+				(xy 80.179538 116.780085) (xy 80.18781 116.776659)
+			)
+		)
+	)
+	(zone
+		(net 85)
+		(net_name "/MCU/SPI2_SCK")
+		(layer "B.Cu")
+		(uuid "9b0e341b-2345-4f80-880b-18631b74864c")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30040)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 85.814122 99.026254) (xy 86.026254 98.814122) (xy 85.749441 98.333329) (xy 85.499293 98.499293)
+				(xy 85.333329 98.749441)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 85.755269 98.343502) (xy 85.75566 98.344132) (xy 86.02178 98.806351) (xy 86.022938 98.815231)
+				(xy 86.019913 98.820462) (xy 85.820462 99.019913) (xy 85.812189 99.02334) (xy 85.806351 99.02178)
+				(xy 85.344132 98.75566) (xy 85.338672 98.748562) (xy 85.33983 98.739682) (xy 85.34021 98.739068)
+				(xy 85.497985 98.501263) (xy 85.501263 98.497985) (xy 85.739053 98.34022) (xy 85.74784 98.338502)
+			)
+		)
+	)
+	(zone
+		(net 57)
+		(net_name "/MCU/SERVO_EN")
+		(layer "B.Cu")
+		(uuid "9d01a2d8-b3a6-4231-9ca9-58b020296906")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30013)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 61.75 95.905764) (xy 61.45 95.905764) (xy 61.305764 96.441473) (xy 61.6 96.501) (xy 61.894236 96.441473)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 61.749306 95.909191) (xy 61.752331 95.914422) (xy 61.890994 96.429435) (xy 61.889836 96.438315)
+				(xy 61.882738 96.443775) (xy 61.882016 96.443945) (xy 61.60232 96.50053) (xy 61.59768 96.50053)
+				(xy 61.317983 96.443945) (xy 61.310554 96.438945) (xy 61.308835 96.430157) (xy 61.309005 96.429435)
+				(xy 61.447669 95.914422) (xy 61.453129 95.907324) (xy 61.458967 95.905764) (xy 61.741033 95.905764)
+			)
+		)
+	)
+	(zone
+		(net 116)
+		(net_name "/MCU/SPI1_SCK")
+		(layer "B.Cu")
+		(uuid "9e024bf7-f2b7-4533-afeb-801116186363")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30038)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 82.185878 124.973746) (xy 81.973746 125.185878) (xy 82.250559 125.666671) (xy 82.500707 125.500707)
+				(xy 82.666671 125.250559)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 82.193646 124.978218) (xy 82.478798 125.142392) (xy 82.655867 125.244339) (xy 82.661327 125.251437)
+				(xy 82.660169 125.260317) (xy 82.659778 125.260947) (xy 82.502015 125.498734) (xy 82.498734 125.502015)
+				(xy 82.260947 125.659778) (xy 82.252159 125.661497) (xy 82.24473 125.656497) (xy 82.244339 125.655867)
+				(xy 82.016966 125.260947) (xy 81.978218 125.193646) (xy 81.977061 125.184768) (xy 81.980084 125.179539)
+				(xy 82.179538 124.980085) (xy 82.18781 124.976659)
+			)
+		)
+	)
+	(zone
+		(net 107)
+		(net_name "/MCU/SPI1_NSS")
+		(layer "B.Cu")
+		(uuid "ae8e9639-11bb-4615-b51d-e13377305d09")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30035)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 78.685878 125.973746) (xy 78.473746 126.185878) (xy 78.750559 126.666671) (xy 79.000707 126.500707)
+				(xy 79.166671 126.250559)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 78.693646 125.978218) (xy 78.978798 126.142392) (xy 79.155867 126.244339) (xy 79.161327 126.251437)
+				(xy 79.160169 126.260317) (xy 79.159778 126.260947) (xy 79.002015 126.498734) (xy 78.998734 126.502015)
+				(xy 78.760947 126.659778) (xy 78.752159 126.661497) (xy 78.74473 126.656497) (xy 78.744339 126.655867)
+				(xy 78.516966 126.260947) (xy 78.478218 126.193646) (xy 78.477061 126.184768) (xy 78.480084 126.179539)
+				(xy 78.679538 125.980085) (xy 78.68781 125.976659)
 			)
 		)
 	)
@@ -53189,13 +54082,13 @@
 		)
 	)
 	(zone
-		(net 81)
-		(net_name "/MCU/SPI4_NSS")
+		(net 116)
+		(net_name "/MCU/SPI1_SCK")
 		(layer "B.Cu")
-		(uuid "b586084e-53c5-420f-869c-b1796e8c4591")
+		(uuid "b945c2cb-bf92-43c8-a131-9a2196639437")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30022)
+		(priority 30037)
 		(attr
 			(teardrop
 				(type padvia)
@@ -53214,97 +54107,17 @@
 		)
 		(polygon
 			(pts
-				(xy 85.305764 114.35) (xy 85.305764 114.65) (xy 85.841473 114.794236) (xy 85.901 114.5) (xy 85.841473 114.205764)
+				(xy 77.814122 121.026254) (xy 78.026254 120.814122) (xy 77.749441 120.333329) (xy 77.499293 120.499293)
+				(xy 77.333329 120.749441)
 			)
 		)
 		(filled_polygon
 			(layer "B.Cu")
 			(pts
-				(xy 85.838315 114.210163) (xy 85.843775 114.217261) (xy 85.843945 114.217983) (xy 85.90053 114.49768)
-				(xy 85.90053 114.50232) (xy 85.843945 114.782016) (xy 85.838945 114.789445) (xy 85.830157 114.791164)
-				(xy 85.829435 114.790994) (xy 85.314422 114.652331) (xy 85.307324 114.646871) (xy 85.305764 114.641033)
-				(xy 85.305764 114.358966) (xy 85.309191 114.350693) (xy 85.314419 114.347669) (xy 85.829435 114.209005)
-			)
-		)
-	)
-	(zone
-		(net 81)
-		(net_name "/MCU/SPI4_NSS")
-		(layer "B.Cu")
-		(uuid "b7546f63-c2db-455e-8c2f-7a7a34a7db0c")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30000)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 85.194236 114.65) (xy 85.194236 114.35) (xy 84.658527 114.205764) (xy 84.599 114.5) (xy 84.658527 114.794236)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 84.670564 114.209005) (xy 84.70391 114.217983) (xy 85.185579 114.347669) (xy 85.192676 114.353128)
-				(xy 85.194236 114.358966) (xy 85.194236 114.641033) (xy 85.190809 114.649306) (xy 85.185578 114.652331)
-				(xy 84.670564 114.790994) (xy 84.661684 114.789836) (xy 84.656224 114.782738) (xy 84.656059 114.782039)
-				(xy 84.599469 114.502318) (xy 84.599469 114.49768) (xy 84.656055 114.21798) (xy 84.661054 114.210554)
-				(xy 84.669842 114.208835)
-			)
-		)
-	)
-	(zone
-		(net 109)
-		(net_name "/MCU/SPI1_MISO")
-		(layer "B.Cu")
-		(uuid "bb93b063-4fcf-47dc-a815-7e56ecf8943d")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30028)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 80.185878 116.773746) (xy 79.973746 116.985878) (xy 80.250559 117.466671) (xy 80.500707 117.300707)
-				(xy 80.666671 117.050559)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 80.193646 116.778218) (xy 80.478798 116.942392) (xy 80.655867 117.044339) (xy 80.661327 117.051437)
-				(xy 80.660169 117.060317) (xy 80.659778 117.060947) (xy 80.502015 117.298734) (xy 80.498734 117.302015)
-				(xy 80.260947 117.459778) (xy 80.252159 117.461497) (xy 80.24473 117.456497) (xy 80.244339 117.455867)
-				(xy 80.016966 117.060947) (xy 79.978218 116.993646) (xy 79.977061 116.984768) (xy 79.980084 116.979539)
-				(xy 80.179538 116.780085) (xy 80.18781 116.776659)
+				(xy 77.755269 120.343502) (xy 77.75566 120.344132) (xy 78.02178 120.806351) (xy 78.022938 120.815231)
+				(xy 78.019913 120.820462) (xy 77.820462 121.019913) (xy 77.812189 121.02334) (xy 77.806351 121.02178)
+				(xy 77.344132 120.75566) (xy 77.338672 120.748562) (xy 77.33983 120.739682) (xy 77.34021 120.739068)
+				(xy 77.497985 120.501263) (xy 77.501263 120.497985) (xy 77.739053 120.34022) (xy 77.74784 120.338502)
 			)
 		)
 	)
@@ -53312,7 +54125,241 @@
 		(net 128)
 		(net_name "/MCU/SERVO_FDBK")
 		(layer "B.Cu")
-		(uuid "c1c6fbca-027c-45c5-827c-08f66eceef02")
+		(uuid "b9c4b6f0-bea0-47a8-bd23-60f9e00fea2f")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30023)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 79.15 102.405764) (xy 78.85 102.405764) (xy 78.705764 102.941473) (xy 79 103.001) (xy 79.294236 102.941473)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 79.149306 102.409191) (xy 79.152331 102.414422) (xy 79.290994 102.929435) (xy 79.289836 102.938315)
+				(xy 79.282738 102.943775) (xy 79.282016 102.943945) (xy 79.00232 103.00053) (xy 78.99768 103.00053)
+				(xy 78.717983 102.943945) (xy 78.710554 102.938945) (xy 78.708835 102.930157) (xy 78.709005 102.929435)
+				(xy 78.847669 102.414422) (xy 78.853129 102.407324) (xy 78.858967 102.405764) (xy 79.141033 102.405764)
+			)
+		)
+	)
+	(zone
+		(net 55)
+		(net_name "/Flash/IO3")
+		(layer "B.Cu")
+		(uuid "bc96e315-c2b2-4d68-bc43-f3eec0a879f5")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30008)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 61.85 128.69621) (xy 62.15 128.69621) (xy 62.294236 128.160501) (xy 62 128.100974) (xy 61.705764 128.160501)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 62.282017 128.158029) (xy 62.289445 128.163028) (xy 62.291164 128.171816) (xy 62.290994 128.172538)
+				(xy 62.152331 128.687552) (xy 62.146871 128.69465) (xy 62.141033 128.69621) (xy 61.858967 128.69621)
+				(xy 61.850694 128.692783) (xy 61.847669 128.687552) (xy 61.709005 128.172538) (xy 61.710163 128.163658)
+				(xy 61.717261 128.158198) (xy 61.717953 128.158034) (xy 61.997682 128.101443) (xy 62.002318 128.101443)
+			)
+		)
+	)
+	(zone
+		(net 13)
+		(net_name "/MCU/BATT_VSENSE")
+		(layer "B.Cu")
+		(uuid "c27d9cd4-5da9-4749-911f-20052f6e5e7c")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30014)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 78.15 100.405764) (xy 77.85 100.405764) (xy 77.705764 100.941473) (xy 78 101.001) (xy 78.294236 100.941473)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 78.149306 100.409191) (xy 78.152331 100.414422) (xy 78.290994 100.929435) (xy 78.289836 100.938315)
+				(xy 78.282738 100.943775) (xy 78.282016 100.943945) (xy 78.00232 101.00053) (xy 77.99768 101.00053)
+				(xy 77.717983 100.943945) (xy 77.710554 100.938945) (xy 77.708835 100.930157) (xy 77.709005 100.929435)
+				(xy 77.847669 100.414422) (xy 77.853129 100.407324) (xy 77.858967 100.405764) (xy 78.141033 100.405764)
+			)
+		)
+	)
+	(zone
+		(net 57)
+		(net_name "/MCU/SERVO_EN")
+		(layer "B.Cu")
+		(uuid "c35c4553-9192-4d12-a5c6-12a90a543d46")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30015)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 90.605764 63.35) (xy 90.605764 63.65) (xy 91.141473 63.794236) (xy 91.201 63.5) (xy 91.141473 63.205764)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 91.138315 63.210163) (xy 91.143775 63.217261) (xy 91.143945 63.217983) (xy 91.20053 63.49768)
+				(xy 91.20053 63.50232) (xy 91.143945 63.782016) (xy 91.138945 63.789445) (xy 91.130157 63.791164)
+				(xy 91.129435 63.790994) (xy 90.614422 63.652331) (xy 90.607324 63.646871) (xy 90.605764 63.641033)
+				(xy 90.605764 63.358966) (xy 90.609191 63.350693) (xy 90.614419 63.347669) (xy 91.129435 63.209005)
+			)
+		)
+	)
+	(zone
+		(net 75)
+		(net_name "/MCU/IMU_INT2")
+		(layer "B.Cu")
+		(uuid "c41c69a5-c9e0-4302-a509-6efc272466b3")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30020)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 82.65 99.405764) (xy 82.35 99.405764) (xy 82.205764 99.941473) (xy 82.5 100.001) (xy 82.794236 99.941473)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 82.649306 99.409191) (xy 82.652331 99.414422) (xy 82.790994 99.929435) (xy 82.789836 99.938315)
+				(xy 82.782738 99.943775) (xy 82.782016 99.943945) (xy 82.50232 100.00053) (xy 82.49768 100.00053)
+				(xy 82.217983 99.943945) (xy 82.210554 99.938945) (xy 82.208835 99.930157) (xy 82.209005 99.929435)
+				(xy 82.347669 99.414422) (xy 82.353129 99.407324) (xy 82.358967 99.405764) (xy 82.641033 99.405764)
+			)
+		)
+	)
+	(zone
+		(net 49)
+		(net_name "/MCU/BOOT0")
+		(layer "B.Cu")
+		(uuid "c9672859-18fc-47b1-9f58-64d1ca263128")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30011)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 65.05 100.894236) (xy 65.35 100.894236) (xy 65.494236 100.358527) (xy 65.2 100.299) (xy 64.905764 100.358527)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 65.482017 100.356055) (xy 65.489445 100.361054) (xy 65.491164 100.369842) (xy 65.490994 100.370564)
+				(xy 65.352331 100.885578) (xy 65.346871 100.892676) (xy 65.341033 100.894236) (xy 65.058967 100.894236)
+				(xy 65.050694 100.890809) (xy 65.047669 100.885578) (xy 64.909005 100.370564) (xy 64.910163 100.361684)
+				(xy 64.917261 100.356224) (xy 64.917953 100.35606) (xy 65.197682 100.299469) (xy 65.202318 100.299469)
+			)
+		)
+	)
+	(zone
+		(net 128)
+		(net_name "/MCU/SERVO_FDBK")
+		(layer "B.Cu")
+		(uuid "d937454d-8af9-4676-ad16-e19f50b183f4")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30041)
@@ -53349,13 +54396,13 @@
 		)
 	)
 	(zone
-		(net 109)
-		(net_name "/MCU/SPI1_MISO")
+		(net 108)
+		(net_name "/MCU/MAG_INT")
 		(layer "B.Cu")
-		(uuid "ca6ef38a-1f1b-47d5-a594-562f2826648c")
+		(uuid "d9829e1a-506d-4e34-92bf-75e1d25e4726")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30029)
+		(priority 30017)
 		(attr
 			(teardrop
 				(type padvia)
@@ -53374,96 +54421,16 @@
 		)
 		(polygon
 			(pts
-				(xy 78.014122 115.026254) (xy 78.226254 114.814122) (xy 77.949441 114.333329) (xy 77.699293 114.499293)
-				(xy 77.533329 114.749441)
+				(xy 78.65 109.494236) (xy 78.95 109.494236) (xy 79.094236 108.958527) (xy 78.8 108.899) (xy 78.505764 108.958527)
 			)
 		)
 		(filled_polygon
 			(layer "B.Cu")
 			(pts
-				(xy 77.955269 114.343502) (xy 77.95566 114.344132) (xy 78.22178 114.806351) (xy 78.222938 114.815231)
-				(xy 78.219913 114.820462) (xy 78.020462 115.019913) (xy 78.012189 115.02334) (xy 78.006351 115.02178)
-				(xy 77.544132 114.75566) (xy 77.538672 114.748562) (xy 77.53983 114.739682) (xy 77.54021 114.739068)
-				(xy 77.697985 114.501263) (xy 77.701263 114.497985) (xy 77.939053 114.34022) (xy 77.94784 114.338502)
-			)
-		)
-	)
-	(zone
-		(net 12)
-		(net_name "Net-(U2-SW)")
-		(layer "B.Cu")
-		(uuid "d6f31ca9-73f5-4442-9789-1ef977b85816")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30001)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 86.705764 53.45) (xy 86.705764 53.75) (xy 87.241473 53.894236) (xy 87.301 53.6) (xy 87.241473 53.305764)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 87.238315 53.310163) (xy 87.243775 53.317261) (xy 87.243945 53.317983) (xy 87.30053 53.59768)
-				(xy 87.30053 53.60232) (xy 87.243945 53.882016) (xy 87.238945 53.889445) (xy 87.230157 53.891164)
-				(xy 87.229435 53.890994) (xy 86.714422 53.752331) (xy 86.707324 53.746871) (xy 86.705764 53.741033)
-				(xy 86.705764 53.458966) (xy 86.709191 53.450693) (xy 86.714419 53.447669) (xy 87.229435 53.309005)
-			)
-		)
-	)
-	(zone
-		(net 57)
-		(net_name "/MCU/SERVO_EN")
-		(layer "B.Cu")
-		(uuid "dc7bdb5e-8589-4cc9-a5e7-ee0e014e0cff")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30024)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 72.526254 74.185878) (xy 72.314122 73.973746) (xy 71.833329 74.250559) (xy 71.999293 74.500707)
-				(xy 72.249441 74.666671)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 72.320462 73.980086) (xy 72.519913 74.179537) (xy 72.52334 74.18781) (xy 72.52178 74.193648)
-				(xy 72.25566 74.655867) (xy 72.248562 74.661327) (xy 72.239682 74.660169) (xy 72.239052 74.659778)
-				(xy 72.001265 74.502015) (xy 71.997984 74.498734) (xy 71.840221 74.260947) (xy 71.838502 74.252159)
-				(xy 71.843502 74.24473) (xy 71.844132 74.244339) (xy 72.306353 73.978218) (xy 72.315231 73.977061)
+				(xy 79.082017 108.956055) (xy 79.089445 108.961054) (xy 79.091164 108.969842) (xy 79.090994 108.970564)
+				(xy 78.952331 109.485578) (xy 78.946871 109.492676) (xy 78.941033 109.494236) (xy 78.658967 109.494236)
+				(xy 78.650694 109.490809) (xy 78.647669 109.485578) (xy 78.509005 108.970564) (xy 78.510163 108.961684)
+				(xy 78.517261 108.956224) (xy 78.517953 108.95606) (xy 78.797682 108.899469) (xy 78.802318 108.899469)
 			)
 		)
 	)
@@ -53471,7 +54438,7 @@
 		(net 49)
 		(net_name "/MCU/BOOT0")
 		(layer "B.Cu")
-		(uuid "dfb21374-08d1-460f-8d40-6f3cf86f6d3b")
+		(uuid "e6ce17df-35cb-4288-b634-ebcf166e9a9a")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30007)
@@ -53508,248 +54475,10 @@
 		)
 	)
 	(zone
-		(net 31)
-		(net_name "/MCU/SERVO_SIG")
-		(layer "B.Cu")
-		(uuid "e3b8d94e-812b-4c93-88b5-c80798ebe0ae")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30030)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 73.526254 75.185878) (xy 73.314122 74.973746) (xy 72.833329 75.250559) (xy 72.999293 75.500707)
-				(xy 73.249441 75.666671)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 73.320462 74.980086) (xy 73.519913 75.179537) (xy 73.52334 75.18781) (xy 73.52178 75.193648)
-				(xy 73.25566 75.655867) (xy 73.248562 75.661327) (xy 73.239682 75.660169) (xy 73.239052 75.659778)
-				(xy 73.001265 75.502015) (xy 72.997984 75.498734) (xy 72.840221 75.260947) (xy 72.838502 75.252159)
-				(xy 72.843502 75.24473) (xy 72.844132 75.244339) (xy 73.306353 74.978218) (xy 73.315231 74.977061)
-			)
-		)
-	)
-	(zone
-		(net 107)
-		(net_name "/MCU/SPI1_NSS")
-		(layer "B.Cu")
-		(uuid "e4638879-b9a3-48fe-ba23-6f7d96d8c8fb")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30035)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 78.685878 125.973746) (xy 78.473746 126.185878) (xy 78.750559 126.666671) (xy 79.000707 126.500707)
-				(xy 79.166671 126.250559)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 78.693646 125.978218) (xy 78.978798 126.142392) (xy 79.155867 126.244339) (xy 79.161327 126.251437)
-				(xy 79.160169 126.260317) (xy 79.159778 126.260947) (xy 79.002015 126.498734) (xy 78.998734 126.502015)
-				(xy 78.760947 126.659778) (xy 78.752159 126.661497) (xy 78.74473 126.656497) (xy 78.744339 126.655867)
-				(xy 78.516966 126.260947) (xy 78.478218 126.193646) (xy 78.477061 126.184768) (xy 78.480084 126.179539)
-				(xy 78.679538 125.980085) (xy 78.68781 125.976659)
-			)
-		)
-	)
-	(zone
-		(net 75)
-		(net_name "/MCU/IMU_INT2")
-		(layer "B.Cu")
-		(uuid "e8147bab-d998-42d4-a555-2fd8f44efe2f")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30021)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 91.6 82.844237) (xy 91.9 82.844237) (xy 92.044236 82.308528) (xy 91.75 82.249001) (xy 91.455764 82.308528)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 92.032017 82.306056) (xy 92.039445 82.311055) (xy 92.041164 82.319843) (xy 92.040994 82.320565)
-				(xy 91.902331 82.835579) (xy 91.896871 82.842677) (xy 91.891033 82.844237) (xy 91.608967 82.844237)
-				(xy 91.600694 82.84081) (xy 91.597669 82.835579) (xy 91.459005 82.320565) (xy 91.460163 82.311685)
-				(xy 91.467261 82.306225) (xy 91.467953 82.306061) (xy 91.747682 82.24947) (xy 91.752318 82.24947)
-			)
-		)
-	)
-	(zone
-		(net 31)
-		(net_name "/MCU/SERVO_SIG")
-		(layer "B.Cu")
-		(uuid "eb3a2813-9530-4b10-8d48-74aa18b61a90")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30005)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 62.65 95.905764) (xy 62.35 95.905764) (xy 62.205764 96.441473) (xy 62.5 96.501) (xy 62.794236 96.441473)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 62.649306 95.909191) (xy 62.652331 95.914422) (xy 62.790994 96.429435) (xy 62.789836 96.438315)
-				(xy 62.782738 96.443775) (xy 62.782016 96.443945) (xy 62.50232 96.50053) (xy 62.49768 96.50053)
-				(xy 62.217983 96.443945) (xy 62.210554 96.438945) (xy 62.208835 96.430157) (xy 62.209005 96.429435)
-				(xy 62.347669 95.914422) (xy 62.353129 95.907324) (xy 62.358967 95.905764) (xy 62.641033 95.905764)
-			)
-		)
-	)
-	(zone
-		(net 85)
-		(net_name "/MCU/SPI2_SCK")
-		(layer "B.Cu")
-		(uuid "ebff26ce-3d95-41b1-85a7-76fbd8e4a1be")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30040)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 85.814122 99.026254) (xy 86.026254 98.814122) (xy 85.749441 98.333329) (xy 85.499293 98.499293)
-				(xy 85.333329 98.749441)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 85.755269 98.343502) (xy 85.75566 98.344132) (xy 86.02178 98.806351) (xy 86.022938 98.815231)
-				(xy 86.019913 98.820462) (xy 85.820462 99.019913) (xy 85.812189 99.02334) (xy 85.806351 99.02178)
-				(xy 85.344132 98.75566) (xy 85.338672 98.748562) (xy 85.33983 98.739682) (xy 85.34021 98.739068)
-				(xy 85.497985 98.501263) (xy 85.501263 98.497985) (xy 85.739053 98.34022) (xy 85.74784 98.338502)
-			)
-		)
-	)
-	(zone
-		(net 114)
-		(net_name "/MCU/IMU_INT1")
-		(layer "B.Cu")
-		(uuid "f2f2749f-d9ec-4884-9df5-a81e0be8a6bf")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30019)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 92.205764 87.85) (xy 92.205764 88.15) (xy 92.741473 88.294236) (xy 92.801 88) (xy 92.741473 87.705764)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 92.738315 87.710163) (xy 92.743775 87.717261) (xy 92.743945 87.717983) (xy 92.80053 87.99768)
-				(xy 92.80053 88.00232) (xy 92.743945 88.282016) (xy 92.738945 88.289445) (xy 92.730157 88.291164)
-				(xy 92.729435 88.290994) (xy 92.214422 88.152331) (xy 92.207324 88.146871) (xy 92.205764 88.141033)
-				(xy 92.205764 87.858966) (xy 92.209191 87.850693) (xy 92.214419 87.847669) (xy 92.729435 87.709005)
-			)
-		)
-	)
-	(zone
 		(net 102)
 		(net_name "/MCU/SPI2_NSS")
 		(layer "B.Cu")
-		(uuid "f3b5b15a-959f-4b96-83d2-c71131ac7f7c")
+		(uuid "f8d9aa30-e918-4da2-9d53-f10746c56658")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30031)
@@ -53787,13 +54516,13 @@
 		)
 	)
 	(zone
-		(net 82)
-		(net_name "/MCU/SPI4_SCK")
+		(net 85)
+		(net_name "/MCU/SPI2_SCK")
 		(layer "B.Cu")
-		(uuid "f7330969-5bbd-459f-98d5-1dc84a248978")
+		(uuid "facd2eea-eb95-4a86-819b-4bf9d3583e55")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30036)
+		(priority 30039)
 		(attr
 			(teardrop
 				(type padvia)
@@ -53812,17 +54541,18 @@
 		)
 		(polygon
 			(pts
-				(xy 83.414122 114.626254) (xy 83.626254 114.414122) (xy 83.349441 113.933329) (xy 83.099293 114.099293)
-				(xy 82.933329 114.349441)
+				(xy 86.685878 99.473746) (xy 86.473746 99.685878) (xy 86.750559 100.166671) (xy 87.000707 100.000707)
+				(xy 87.166671 99.750559)
 			)
 		)
 		(filled_polygon
 			(layer "B.Cu")
 			(pts
-				(xy 83.355269 113.943502) (xy 83.35566 113.944132) (xy 83.62178 114.406351) (xy 83.622938 114.415231)
-				(xy 83.619913 114.420462) (xy 83.420462 114.619913) (xy 83.412189 114.62334) (xy 83.406351 114.62178)
-				(xy 82.944132 114.35566) (xy 82.938672 114.348562) (xy 82.93983 114.339682) (xy 82.94021 114.339068)
-				(xy 83.097985 114.101263) (xy 83.101263 114.097985) (xy 83.339053 113.94022) (xy 83.34784 113.938502)
+				(xy 86.693646 99.478218) (xy 86.978798 99.642392) (xy 87.155867 99.744339) (xy 87.161327 99.751437)
+				(xy 87.160169 99.760317) (xy 87.159778 99.760947) (xy 87.002015 99.998734) (xy 86.998734 100.002015)
+				(xy 86.760947 100.159778) (xy 86.752159 100.161497) (xy 86.74473 100.156497) (xy 86.744339 100.155867)
+				(xy 86.516966 99.760947) (xy 86.478218 99.693646) (xy 86.477061 99.684768) (xy 86.480084 99.679539)
+				(xy 86.679538 99.480085) (xy 86.68781 99.476659)
 			)
 		)
 	)

--- a/pcb/airbrake_mod.kicad_pcb
+++ b/pcb/airbrake_mod.kicad_pcb
@@ -8198,6 +8198,7 @@
 			(at -0.3 -1.4 0)
 			(unlocked yes)
 			(layer "F.SilkS")
+			(hide yes)
 			(uuid "9ea1a28f-35ce-41a6-a7ab-74d8d6bcdf8b")
 			(effects
 				(font
@@ -12617,7 +12618,7 @@
 		(descr "Test Point Chip 0603 (1.6mmx0.8mm) RCU RC")
 		(tags "Test Point Chip 0603 (1.6mmx0.8mm) RCU RC")
 		(property "Reference" "TP2"
-			(at 2.1 -0.5 0)
+			(at 1.6 -0.5 0)
 			(unlocked yes)
 			(layer "F.SilkS")
 			(uuid "f5b40eef-deb0-41a6-a7de-4295219fdacd")
@@ -14866,7 +14867,7 @@
 		(descr "Test Point Chip 0603 (1.6mmx0.8mm) RCU RC")
 		(tags "Test Point Chip 0603 (1.6mmx0.8mm) RCU RC")
 		(property "Reference" "TP5"
-			(at 2 0.7 0)
+			(at 1.6 0.3 0)
 			(unlocked yes)
 			(layer "F.SilkS")
 			(uuid "48fd4c18-fcc2-4d34-b060-ebc208a5738c")
@@ -32213,6 +32214,18 @@
 				(thickness 0.15)
 			)
 			(justify left bottom)
+		)
+	)
+	(gr_text "BUCK\nIN"
+		(at 89.2 60.7 90)
+		(layer "F.SilkS")
+		(uuid "46c359ad-072b-4f88-8474-459ae1d705f8")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify right)
 		)
 	)
 	(gr_text "MOSI"


### PR DESCRIPTION
All SPI test point reference designators replaced with named labels
BUCK_IN labeled. Other power supply test points remain as reference designators due to naming complexity.